### PR TITLE
Switch backend to leapmotor-api, add sensors and partial positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,23 @@ It intentionally does not contain:
 - Mileage/energy-history summary sensors
 - Native Home Assistant lock entity for remote lock/unlock actions
 - Charge-cable plugged-in state and active-charging state
+- Regenerative braking state
 - Door and trunk open states
+- Climate, heating, and seat state sensors
+- Window and sunshade position sensors
+- Vehicle notification message sensors (unread count, last message title and time)
 - Device tracker from vehicle GPS position
 - Remote-control buttons for supported actions
+- Partial window and sunshade positioning via service `value` parameter
 - Native Home Assistant services for supported remote actions
 - Send destination to vehicle navigation via Home Assistant service
 - Optional ABRP Generic Telemetry live-data push
 - Setup/options flow for vehicle PIN, update interval, and optional ABRP token
 - Redacted diagnostics export
-- Multi-language translations
+- Multi-language translations (EN, DE, NL, FR, ES, IT, PL)
 - Multi-vehicle support for main-account and shared-car vehicles
 - HACS and Home Assistant brand/icon assets
-- Single Custom Component package with entity layer and backend/auth layer
+- Uses [`leapmotor-api`](https://github.com/markoceri/leapmotor-api) as the backend library
 
 ## Important
 
@@ -55,13 +60,14 @@ The public install target is one Home Assistant Custom Component:
 Internal architecture:
 
 - the Home Assistant integration manages entities, config flow, and UI
-- the backend/auth layer manages login, session, certificate, vehicle data, and command calls
+- the backend/auth layer is provided by [`leapmotor-api`](https://github.com/markoceri/leapmotor-api), an extracted standalone library, wrapped by a thin shim inside the integration
+- the shim adds extra read calls (weekly consumption, last-week energy breakdown, notifications) that are not yet in the base library
 
 Current reality:
 
-- the integration code still supports direct login with local certificate files
-- the internal backend path covers login, vehicle list, status, and remote commands
-- additional read-only calls cover total mileage and charging-plan details
+- the integration uses `leapmotor-api` as a pip dependency for login, session management, certificate handling, vehicle data, and remote commands
+- additional read-only calls cover total mileage, consumption rankings, energy breakdown, and the notification message list
+- token refresh uses the `/acct/v1/token/refresh` endpoint before falling back to a full re-login
 
 Expected local files for persistent storage:
 
@@ -127,11 +133,11 @@ The integration exposes these Home Assistant services under `leapmotor.*`:
 - `trunk_open`
 - `trunk_close`
 - `find_car`
-- `sunshade_open`
-- `sunshade_close`
+- `sunshade_open` — accepts optional `value` (0–10, 10 = fully open)
+- `sunshade_close` — accepts optional `value` (0–10, 0 = fully closed)
 - `battery_preheat`
-- `windows_open`
-- `windows_close`
+- `windows_open` — accepts optional `value` (0–100, 100 = fully open)
+- `windows_close` — accepts optional `value` (0–100, 0 = fully closed)
 - `ac_switch` (climate off)
 - `quick_cool`
 - `quick_heat`
@@ -145,6 +151,9 @@ Each service accepts:
 
 `send_destination` additionally requires `name`, `latitude`, and `longitude`.
 `address` is optional and defaults to `name`.
+
+Omitting `value` on `windows_open` / `sunshade_open` sends the default fully-open command.
+Omitting `value` on `windows_close` / `sunshade_close` sends the default fully-closed command.
 
 ## ABRP Live Data
 
@@ -209,6 +218,7 @@ Whole kilometer values are exposed as integers so Home Assistant displays
 
 - Keep improving status mapping across more Leapmotor models.
 - Keep investigating a future login path that does not need local app certificate material.
+- Upstream window/sunshade consumption endpoints and notification API into `leapmotor-api` so the integration shim can shrink.
 - Add more write features only after the exact app request, safety model, and permission behavior are verified.
 
 ## Legal

--- a/custom_components/leapmotor/__init__.py
+++ b/custom_components/leapmotor/__init__.py
@@ -35,6 +35,16 @@ SERVICE_FIELDS = vol.Schema(
     }
 )
 
+PARAMETERIZED_SERVICE_FIELDS = vol.Schema(
+    {
+        vol.Optional("value"): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+        vol.Optional("vin"): str,
+        vol.Optional("entity_id"): str,
+    }
+)
+
+_PARAMETERIZED_SERVICES = {"windows_open", "windows_close", "sunshade_open", "sunshade_close"}
+
 SET_CHARGE_LIMIT_FIELDS = vol.Schema(
     {
         vol.Required("charge_limit_percent"): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
@@ -154,7 +164,9 @@ async def _async_register_services(hass: HomeAssistant) -> None:
                 "No matching Leapmotor vehicle found. Specify a VIN if multiple vehicles are configured."
             )
 
-        await async_execute_remote_action(coordinator, target_vin, action_spec)
+        raw_value = call.data.get("value")
+        kwargs = {"value": str(raw_value)} if raw_value is not None else None
+        await async_execute_remote_action(coordinator, target_vin, action_spec, kwargs)
 
     async def handle_set_charge_limit(call: ServiceCall) -> None:
         domain_data = hass.data.get(DOMAIN) or {}
@@ -274,11 +286,12 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         return _handler
 
     for service_name in ("lock", "unlock", *(spec.service_name for spec in BUTTON_SPECS)):
+        schema = PARAMETERIZED_SERVICE_FIELDS if service_name in _PARAMETERIZED_SERVICES else SERVICE_FIELDS
         hass.services.async_register(
             DOMAIN,
             service_name,
             make_handler(service_name),
-            schema=SERVICE_FIELDS,
+            schema=schema,
         )
         _LOGGER.debug("Registered Leapmotor service %s.%s", DOMAIN, service_name)
     hass.services.async_register(

--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1,147 +1,56 @@
-"""Leapmotor cloud API client."""
+"""Compatibility shim: wraps leapmotor_api for use inside the HA integration."""
 
 from __future__ import annotations
 
-import base64
 import hashlib
 import hmac
-import json
 import logging
 import random
-import subprocess
-import tempfile
 import time
-from dataclasses import dataclass
+
+_LOGGER = logging.getLogger(__name__)
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
-import requests
-import urllib3
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.primitives.serialization import pkcs12
-
-from .const import (
+from leapmotor_api import LeapmotorApiClient as _LeapmotorApiClient
+from leapmotor_api import normalize_vehicle
+from leapmotor_api.const import (
     DEFAULT_APP_VERSION,
     DEFAULT_BASE_URL,
     DEFAULT_CHANNEL,
-    DEFAULT_DEVICE_ID,
     DEFAULT_DEVICE_TYPE,
     DEFAULT_LANGUAGE,
-    DEFAULT_OPERPWD_AES_IV,
-    DEFAULT_OPERPWD_AES_KEY,
     DEFAULT_P12_ENC_ALG,
     DEFAULT_SOURCE,
-    KNOWN_ACCOUNT_P12_PASSWORDS,
-    REMOTE_CTL_AC_SWITCH,
-    REMOTE_CTL_BATTERY_PREHEAT,
-    REMOTE_CTL_FIND_CAR,
-    REMOTE_CTL_LOCK,
-    REMOTE_CTL_QUICK_COOL,
-    REMOTE_CTL_QUICK_HEAT,
-    REMOTE_CTL_SUNSHADE,
-    REMOTE_CTL_SUNSHADE_CLOSE,
-    REMOTE_CTL_SUNSHADE_OPEN,
-    REMOTE_CTL_TRUNK,
-    REMOTE_CTL_TRUNK_CLOSE,
-    REMOTE_CTL_TRUNK_OPEN,
-    REMOTE_CTL_UNLOCK,
-    REMOTE_CTL_WINDSHIELD_DEFROST,
-    REMOTE_CTL_WINDOWS,
-    REMOTE_CTL_WINDOWS_CLOSE,
-    REMOTE_CTL_WINDOWS_OPEN,
-    STATIC_APP_CERT,
-    STATIC_APP_KEY,
 )
-from .p12 import derive_account_p12_password
+from leapmotor_api.exceptions import (
+    LeapmotorApiError,
+    LeapmotorAuthError,
+    LeapmotorMissingAppCertError,
+)
+from leapmotor_api.models import Vehicle
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+__all__ = [
+    "LeapmotorApiClient",
+    "LeapmotorApiError",
+    "LeapmotorAuthError",
+    "LeapmotorMissingAppCertError",
+    "LeapmotorNoVehicleError",
+]
 
-_LOGGER = logging.getLogger(__name__)
-
-
-class LeapmotorApiError(Exception):
-    """Base Leapmotor API error."""
-
-
-class LeapmotorAuthError(LeapmotorApiError):
-    """Leapmotor authentication failed."""
-
-
-class LeapmotorAccountCertError(LeapmotorAuthError):
-    """Leapmotor account certificate could not be opened."""
-
-
-class LeapmotorMissingAppCertError(LeapmotorAuthError):
-    """Local app certificate material is missing."""
+_STATIC_APP_CERT = "app_cert.pem"
+_STATIC_APP_KEY = "app_key.pem"
 
 
 class LeapmotorNoVehicleError(LeapmotorApiError):
-    """The account login worked, but no vehicle is linked to the account."""
+    """No vehicle linked to this account."""
 
 
-@dataclass(slots=True)
-class Vehicle:
-    """Vehicle metadata from the vehicle list."""
-
-    vin: str
-    car_id: str | None
-    car_type: str
-    nickname: str | None
-    is_shared: bool
-    year: int | None = None
-    rights: str | None = None
-    abilities: list[str] | None = None
-    module_rights: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class RemoteActionSpec:
-    """Verified remote-control action payload."""
-
-    cmd_id: str
-    cmd_content: str
-
-
-REMOTE_ACTION_SPECS: dict[str, RemoteActionSpec] = {
-    REMOTE_CTL_UNLOCK: RemoteActionSpec(cmd_id="110", cmd_content='{"value":"unlock"}'),
-    REMOTE_CTL_LOCK: RemoteActionSpec(cmd_id="110", cmd_content='{"value":"lock"}'),
-    REMOTE_CTL_TRUNK: RemoteActionSpec(cmd_id="130", cmd_content='{"value":"true"}'),
-    REMOTE_CTL_TRUNK_OPEN: RemoteActionSpec(cmd_id="130", cmd_content='{"value":"true"}'),
-    REMOTE_CTL_TRUNK_CLOSE: RemoteActionSpec(cmd_id="130", cmd_content='{"value":"false"}'),
-    REMOTE_CTL_FIND_CAR: RemoteActionSpec(cmd_id="120", cmd_content='{"value":"true"}'),
-    REMOTE_CTL_SUNSHADE: RemoteActionSpec(cmd_id="240", cmd_content='{"value":"10"}'),
-    REMOTE_CTL_SUNSHADE_OPEN: RemoteActionSpec(cmd_id="240", cmd_content='{"value":"10"}'),
-    REMOTE_CTL_SUNSHADE_CLOSE: RemoteActionSpec(cmd_id="240", cmd_content='{"value":"0"}'),
-    REMOTE_CTL_BATTERY_PREHEAT: RemoteActionSpec(cmd_id="160", cmd_content='{"value":"ptcon"}'),
-    REMOTE_CTL_WINDOWS: RemoteActionSpec(cmd_id="230", cmd_content='{"value":"2"}'),
-    REMOTE_CTL_WINDOWS_OPEN: RemoteActionSpec(cmd_id="230", cmd_content='{"value":"2"}'),
-    REMOTE_CTL_WINDOWS_CLOSE: RemoteActionSpec(cmd_id="230", cmd_content='{"value":"0"}'),
-    REMOTE_CTL_AC_SWITCH: RemoteActionSpec(
-        cmd_id="170",
-        cmd_content='{"circle":"out","mode":"nohotcold","operate":"manual","position":"all","temperature":"24","windlevel":"4","wshld":"1"}',
-    ),
-    REMOTE_CTL_QUICK_COOL: RemoteActionSpec(
-        cmd_id="170",
-        cmd_content='{"circle":"in","mode":"cold","operate":"manual","position":"all","temperature":"18","windlevel":"7","wshld":"1"}',
-    ),
-    REMOTE_CTL_QUICK_HEAT: RemoteActionSpec(
-        cmd_id="170",
-        cmd_content='{"circle":"in","mode":"hot","operate":"manual","position":"all","temperature":"32","windlevel":"7","wshld":"1"}',
-    ),
-    REMOTE_CTL_WINDSHIELD_DEFROST: RemoteActionSpec(
-        cmd_id="170",
-        cmd_content='{"circle":"in","mode":"hot","operate":"manual","position":"all","temperature":"32","windlevel":"7","wshld":"2"}',
-    ),
-}
-
-
-class LeapmotorApiClient:
-    """Minimal client based on reverse-engineered Leapmotor app traffic."""
+class LeapmotorApiClient(_LeapmotorApiClient):
+    """HA integration wrapper — adapts static_cert_dir and adds extra history endpoints."""
 
     def __init__(
         self,
@@ -153,400 +62,96 @@ class LeapmotorApiClient:
         base_url: str = DEFAULT_BASE_URL,
         static_cert_dir: str | Path | None = None,
     ) -> None:
-        self.username = username
-        self.password = password
-        self.operation_password = operation_password.strip() if operation_password else None
-        self.account_p12_password = account_p12_password
-        self.base_url = base_url.rstrip("/")
-        self.session = requests.Session()
-        self.device_id = DEFAULT_DEVICE_ID
-        self.user_id: str | None = None
-        self.token: str | None = None
-        self.sign_ikm: str | None = None
-        self.sign_salt: str | None = None
-        self.sign_info: str | None = None
-        self.account_cert_file: str | None = None
-        self.account_key_file: str | None = None
-        self.account_p12_password_used: str | None = None
-        self.account_p12_password_source: str | None = None
-        self.remote_cert_synced = False
-        self.last_api_results: dict[str, dict[str, Any]] = {}
         cert_dir = Path(static_cert_dir) if static_cert_dir else Path(__file__).resolve().parent
-        self.static_cert = str(cert_dir / STATIC_APP_CERT)
-        self.static_key = str(cert_dir / STATIC_APP_KEY)
-
-    def close(self) -> None:
-        """Close HTTP resources and remove temporary account cert files."""
-        self.session.close()
-        self._clear_account_cert_files()
-
-    def _clear_account_cert_files(self) -> None:
-        """Remove temporary account cert files."""
-        for file_name in (self.account_cert_file, self.account_key_file):
-            if file_name:
-                try:
-                    Path(file_name).unlink(missing_ok=True)
-                except OSError:
-                    pass
-        self.account_cert_file = None
-        self.account_key_file = None
-
-    def _clear_auth(self) -> None:
-        """Clear token and account certificate state before re-login."""
-        self.token = None
-        self.device_id = DEFAULT_DEVICE_ID
-        self.user_id = None
-        self.sign_ikm = None
-        self.sign_salt = None
-        self.sign_info = None
-        self.account_p12_password_used = None
-        self.account_p12_password_source = None
-        self.remote_cert_synced = False
-        self._clear_account_cert_files()
-
-    @property
-    def account_cert(self) -> tuple[str, str]:
-        if not self.account_cert_file or not self.account_key_file:
-            raise LeapmotorAuthError("No account certificate loaded.")
-        return (self.account_cert_file, self.account_key_file)
-
-    @property
-    def sign_key(self) -> bytes:
-        if self.sign_ikm is None or self.sign_salt is None or self.sign_info is None:
-            raise LeapmotorAuthError("No account sign material loaded.")
-        return HKDF(
-            algorithm=hashes.SHA256(),
-            length=32,
-            salt=self.sign_salt.encode("utf-8"),
-            info=self.sign_info.encode("utf-8"),
-        ).derive(self.sign_ikm.encode("utf-8"))
-
-    def _ensure_static_cert_files(self) -> None:
-        """Require local app certificate material for the current login flow."""
-        missing = [
-            path.name
-            for path in (Path(self.static_cert), Path(self.static_key))
-            if not path.exists()
-        ]
-        if missing:
-            raise LeapmotorMissingAppCertError(
-                "Missing local app certificate material: "
-                + ", ".join(missing)
-                + ". This public repository does not ship app_cert.pem/app_key.pem."
-            )
-
-    def fetch_data(self) -> dict[str, Any]:
-        """Authenticate if needed and fetch all read-only vehicle data."""
-        if not self.token:
-            self._ensure_static_cert_files()
-            self.login()
-
-        try:
-            return self._fetch_authenticated_data()
-        except LeapmotorApiError:
-            self._clear_auth()
-            self._ensure_static_cert_files()
-            self.login()
-            return self._fetch_authenticated_data()
-
-    def lock_vehicle(self, vin: str) -> dict[str, Any]:
-        """Lock one vehicle via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_LOCK)
-
-    def unlock_vehicle(self, vin: str) -> dict[str, Any]:
-        """Unlock one vehicle via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_UNLOCK)
-
-    def open_trunk(self, vin: str) -> dict[str, Any]:
-        """Open the trunk via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_TRUNK)
-
-    def close_trunk(self, vin: str) -> dict[str, Any]:
-        """Close the trunk via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_TRUNK_CLOSE)
-
-    def find_vehicle(self, vin: str) -> dict[str, Any]:
-        """Locate the vehicle via horn."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_FIND_CAR)
-
-    def control_sunshade(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified sunshade action."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_SUNSHADE)
-
-    def open_sunshade(self, vin: str) -> dict[str, Any]:
-        """Open the sunshade via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_SUNSHADE_OPEN)
-
-    def close_sunshade(self, vin: str) -> dict[str, Any]:
-        """Close the sunshade via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_SUNSHADE_CLOSE)
-
-    def battery_preheat(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified battery-preheat action."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_BATTERY_PREHEAT)
-
-    def windows(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified window action."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_WINDOWS)
-
-    def open_windows(self, vin: str) -> dict[str, Any]:
-        """Open the windows via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_WINDOWS_OPEN)
-
-    def close_windows(self, vin: str) -> dict[str, Any]:
-        """Close the windows via remote control."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_WINDOWS_CLOSE)
-
-    def ac_switch(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified A/C switch profile."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_AC_SWITCH)
-
-    def quick_cool(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified quick-cool profile."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_QUICK_COOL)
-
-    def quick_heat(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified quick-heat profile."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_QUICK_HEAT)
-
-    def windshield_defrost(self, vin: str) -> dict[str, Any]:
-        """Trigger the verified windshield-defrost profile."""
-        return self._remote_control(vin=vin, action=REMOTE_CTL_WINDSHIELD_DEFROST)
-
-    def set_charge_limit(self, vin: str, charge_limit_percent: int) -> dict[str, Any]:
-        """Set the charge limit while preserving the current charging plan values."""
-        vehicle = self._find_vehicle_by_vin(vin)
-        status_json = self.get_vehicle_status(vehicle)
-        charge_plan = (((status_json.get("data") or {}).get("config") or {}).get("3") or {})
-
-        start_time = charge_plan.get("beginTime")
-        end_time = charge_plan.get("endTime")
-        cycles = charge_plan.get("cycles")
-        if not start_time or not end_time or not cycles:
-            raise LeapmotorApiError(
-                "Current charging plan is incomplete, cannot safely update charge limit."
-            )
-
-        cmd_content = json.dumps(
-            {
-                "chargeEnable": 1 if _safe_int(charge_plan.get("isEnable")) else 0,
-                "chargesoc": int(charge_limit_percent),
-                "circulation": _safe_int(charge_plan.get("circulation")) or 0,
-                "cycles": str(cycles),
-                "endtime": str(end_time),
-                "recharge": _safe_int(charge_plan.get("recharge")) or 0,
-                "starttime": str(start_time),
-            },
-            separators=(",", ":"),
-        )
-        return self._remote_control_raw(
-            vin=vin,
-            cmd_id="190",
-            cmd_content=cmd_content,
-            action_label="set_charge_limit",
-            vehicle=vehicle,
+        super().__init__(
+            username=username,
+            password=password,
+            app_cert_path=cert_dir / _STATIC_APP_CERT,
+            app_key_path=cert_dir / _STATIC_APP_KEY,
+            operation_password=operation_password,
+            account_p12_password=account_p12_password,
+            base_url=base_url,
         )
 
-    def send_destination(
-        self,
-        vin: str,
-        *,
-        address: str,
-        address_name: str,
-        latitude: float,
-        longitude: float,
-    ) -> dict[str, Any]:
-        """Send a navigation destination to the vehicle."""
-        vehicle = self._find_vehicle_by_vin(vin)
-        cmd_content = json.dumps(
-            {
-                "address": address,
-                "addressname": address_name,
-                "latitude": str(latitude),
-                "linenum": "0",
-                "longitude": str(longitude),
-            },
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
-        return self._remote_control_without_pin_raw(
-            vin=vehicle.vin,
-            cmd_id="180",
-            cmd_content=cmd_content,
-            action_label="send_destination",
-        )
+    # ------------------------------------------------------------------
+    # Override: add consumption history + is_plugged to each vehicle dict
+    # ------------------------------------------------------------------
 
     def _fetch_authenticated_data(self) -> dict[str, Any]:
-        """Fetch all read-only vehicle data with a current session."""
         vehicles = self.get_vehicle_list()
         result: dict[str, Any] = {
             "user_id": self.user_id,
             "vehicles": {},
             "account_p12_password_source": self.account_p12_password_source,
         }
+        message_list = self._fetch_message_list()
         for vehicle in vehicles:
-            status = self.get_vehicle_status(vehicle)
-            mileage = self._fetch_optional_read(
-                "mileage energy detail",
-                self.get_mileage_energy_detail,
-                vehicle,
+            status = self.get_vehicle_raw_status(vehicle)
+            mileage = self._fetch_optional_read("mileage energy detail", self.get_mileage_energy_detail, vehicle)
+            rank = self._fetch_optional_read("consumption weekly rank", self.get_consumption_weekly_rank, vehicle)
+            breakdown = self._fetch_optional_read(
+                "consumption last week breakdown", self.get_consumption_last_week_breakdown, vehicle
             )
-            consumption_rank = self._fetch_optional_read(
-                "consumption weekly rank",
-                self.get_consumption_weekly_rank,
-                vehicle,
-            )
-            consumption_breakdown = self._fetch_optional_read(
-                "consumption last week breakdown",
-                self.get_consumption_last_week_breakdown,
-                vehicle,
-            )
-            picture = self._fetch_optional_read(
-                "car picture",
-                self.get_car_picture,
-                vehicle,
-            )
-            result["vehicles"][vehicle.vin] = normalize_vehicle(
-                vehicle,
-                status,
-                self.user_id,
-                mileage_json=mileage,
-                consumption_rank_json=consumption_rank,
-                consumption_breakdown_json=consumption_breakdown,
-                picture_json=picture,
-            )
+            picture = self._fetch_optional_read("car picture", self.get_car_picture, vehicle)
+            vehicle_data = normalize_vehicle(vehicle, status, self.user_id, mileage_json=mileage, picture_json=picture)
+            _augment_history(vehicle_data["history"], mileage, rank, breakdown)
+            _augment_charging(vehicle_data["charging"], status)
+            vehicle_data["messages"] = _build_messages_dict(vehicle.vin, message_list)
+            _augment_status(vehicle_data["status"], status)
+            _augment_windows(vehicle_data, status)
+            result["vehicles"][vehicle.vin] = vehicle_data
         return result
 
-    def _fetch_optional_read(
-        self,
-        label: str,
-        fetcher: Any,
-        vehicle: Vehicle,
-    ) -> dict[str, Any] | None:
-        """Fetch optional read-only data without failing the whole update."""
+    def _fetch_message_list(self) -> list[Any] | None:
         try:
-            return fetcher(vehicle)
+            return self.get_message_list(page_size=50).messages
         except LeapmotorApiError as exc:
-            _LOGGER.debug("Leapmotor optional read failed for %s: %s", label, exc)
+            _LOGGER.debug("Leapmotor optional read failed for message list: %s", exc)
             return None
 
-    def login(self) -> None:
-        """Login with the static app cert and load the account cert from the response."""
-        self._ensure_static_cert_files()
-        headers = self._build_login_headers()
-        body = self._build_login_form_body()
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/acct/v1/login",
-            headers=headers,
-            data=body,
-            cert=(self.static_cert, self.static_key),
-        )
-        data = self._parse_api_body(response["status_code"], response["body"], "login")
-        login_data = data.get("data") or {}
-        self.user_id = str(login_data.get("id"))
-        self.token = str(login_data.get("token"))
-        self.device_id = self._derive_session_device_id(self.token)
-        self.sign_ikm = str(login_data.get("signIkm"))
-        self.sign_salt = str(login_data.get("signSalt"))
-        self.sign_info = str(login_data.get("signInfo"))
-        self._load_account_cert(login_data)
-        self.remote_cert_synced = False
-
-    def get_vehicle_list(self) -> list[Vehicle]:
-        """Fetch the account vehicle list."""
-        headers = self._build_signed_headers()
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/list",
-            headers=headers,
-            data="",
-            cert=self.account_cert,
-        )
-        body = self._parse_api_body(response["status_code"], response["body"], "vehicle list")
-        list_data = body.get("data") or {}
-        vehicles: list[Vehicle] = []
-        for bucket, is_shared in (("bindcars", False), ("sharedcars", True)):
-            for item in list_data.get(bucket, []) or []:
-                vin = item.get("vin")
-                if not vin:
-                    continue
-                vehicles.append(
-                    Vehicle(
-                        vin=str(vin),
-                        car_id=str(item["carId"]) if item.get("carId") is not None else None,
-                        car_type=str(item.get("carType") or "C10"),
-                        nickname=item.get("nickName"),
-                        is_shared=is_shared,
-                        year=_safe_int(item.get("year")),
-                        rights=item.get("rightList"),
-                        abilities=[str(value) for value in item.get("abilities") or []],
-                        module_rights=item.get("moduleRights"),
-                    )
-                )
-        return vehicles
-
-    def get_vehicle_status(self, vehicle: Vehicle) -> dict[str, Any]:
-        """Fetch read-only status for one vehicle."""
-        car_type_path = _vehicle_status_car_type_path(vehicle.car_type)
-        headers = self._build_signed_headers(vin=vehicle.vin)
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        response = self._post_with_curl(
-            path=f"/carownerservice/oversea/vehicle/v1/status/get/{car_type_path}",
-            headers=headers,
-            data=f"vin={requests.utils.quote(vehicle.vin, safe='')}",
-            cert=self.account_cert,
-        )
-        return self._parse_api_body(response["status_code"], response["body"], "vehicle status")
-
-    def get_mileage_energy_detail(self, vehicle: Vehicle) -> dict[str, Any]:
-        """Fetch read-only mileage and energy history summary."""
-        begintime, endtime = _last_seven_day_window_ms()
-        headers = self._build_mileage_energy_detail_headers(
-            vin=vehicle.vin,
-            begintime=str(begintime),
-            endtime=str(endtime),
-        )
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        body = (
-            f"endtime={endtime}"
-            f"&begintime={begintime}"
-            f"&vin={requests.utils.quote(vehicle.vin, safe='')}"
-        )
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/drivingRecord/v1/mileage/energy/detail",
-            headers=headers,
-            data=body,
-            cert=self.account_cert,
-        )
-        return self._parse_api_body(response["status_code"], response["body"], "mileage energy detail")
+    # ------------------------------------------------------------------
+    # Extra read endpoints not yet in leapmotor_api
+    # ------------------------------------------------------------------
 
     def get_consumption_weekly_rank(self, vehicle: Vehicle) -> dict[str, Any]:
-        """Fetch read-only six-week energy consumption and ranking data."""
-        headers = self._build_consumption_weekly_rank_headers(carvin=vehicle.vin)
+        """Fetch six-week energy consumption and ranking data."""
+        self._ensure_token()
+        return self._retry_on_token_expiry(self._get_consumption_weekly_rank, vehicle)
+
+    def _get_consumption_weekly_rank(self, vehicle: Vehicle) -> dict[str, Any]:
+        nonce = str(random.randint(100000, 9999999))
+        timestamp = str(int(time.time() * 1000))
+        sign_input = "".join([
+            DEFAULT_LANGUAGE, vehicle.vin, DEFAULT_CHANNEL, self.device_id,
+            DEFAULT_DEVICE_TYPE, nonce, DEFAULT_SOURCE, timestamp, DEFAULT_APP_VERSION,
+        ])
+        headers = _build_signed_headers(self.sign_key, self.device_id, nonce, timestamp, sign_input)
         headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        response = self._post_with_curl(
+        response = self._post(
             path="/carownerservice/oversea/drivingRecord/v1/getLastNweeks100kmECAndRank",
             headers=headers,
-            data=f"carvin={requests.utils.quote(vehicle.vin, safe='')}",
+            data=f"carvin={quote(vehicle.vin, safe='')}",
             cert=self.account_cert,
         )
         return self._parse_api_body(response["status_code"], response["body"], "consumption weekly rank")
 
     def get_consumption_last_week_breakdown(self, vehicle: Vehicle) -> dict[str, Any]:
-        """Fetch read-only last-week energy split by driving, A/C, and other."""
+        """Fetch last-week energy split by driving, A/C, and other."""
+        self._ensure_token()
+        return self._retry_on_token_expiry(self._get_consumption_last_week_breakdown, vehicle)
+
+    def _get_consumption_last_week_breakdown(self, vehicle: Vehicle) -> dict[str, Any]:
         begintime, endtime = _previous_week_window_seconds()
-        headers = self._build_consumption_last_week_headers(
-            carvin=vehicle.vin,
-            begintime=str(begintime),
-            endtime=str(endtime),
-        )
+        nonce = str(random.randint(100000, 9999999))
+        timestamp = str(int(time.time() * 1000))
+        sign_input = "".join([
+            DEFAULT_LANGUAGE, str(begintime), vehicle.vin, DEFAULT_CHANNEL, self.device_id,
+            DEFAULT_DEVICE_TYPE, str(endtime), nonce, DEFAULT_SOURCE, timestamp, DEFAULT_APP_VERSION,
+        ])
+        headers = _build_signed_headers(self.sign_key, self.device_id, nonce, timestamp, sign_input)
         headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        body = (
-            f"endtime={endtime}"
-            f"&begintime={begintime}"
-            f"&carvin={requests.utils.quote(vehicle.vin, safe='')}"
-        )
-        response = self._post_with_curl(
+        body = f"endtime={endtime}&begintime={begintime}&carvin={quote(vehicle.vin, safe='')}"
+        response = self._post(
             path="/carownerservice/oversea/drivingRecord/v1/getLastweekEC",
             headers=headers,
             data=body,
@@ -554,1068 +159,116 @@ class LeapmotorApiClient:
         )
         return self._parse_api_body(response["status_code"], response["body"], "consumption last week breakdown")
 
-    def get_car_picture(self, vehicle: Vehicle) -> dict[str, Any]:
-        """Fetch read-only car picture metadata."""
-        headers = self._build_car_picture_headers(vin=vehicle.vin)
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        body = (
-            f"deviceID={requests.utils.quote(self.device_id, safe='')}"
-            f"&vin={requests.utils.quote(vehicle.vin, safe='')}"
-        )
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/carpicture/key",
-            headers=headers,
-            data=body,
-            cert=self.account_cert,
-        )
-        return self._parse_api_body(response["status_code"], response["body"], "car picture")
 
-    def download_car_picture_package(self, *, picture_key: str) -> bytes:
-        """Download the picture package ZIP for one already-resolved picture key."""
-        headers = self._build_car_picture_package_headers(picture_key=picture_key)
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        response = self._post_binary_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/carpicture/package",
-            headers=headers,
-            data=f"key={requests.utils.quote(picture_key, safe='')}",
-            cert=self.account_cert,
-        )
-        if response["status_code"] != 200:
-            raise LeapmotorApiError(
-                f"car picture package failed with HTTP {response['status_code']}"
-            )
-        return response["body"]
+# ------------------------------------------------------------------
+# Module-level helpers
+# ------------------------------------------------------------------
 
-    def _remote_control(self, *, vin: str, action: str) -> dict[str, Any]:
-        """Execute a remote-control action using the verified operatePassword flow."""
-        if not self.token:
-            self.login()
-        if not self.operation_password:
-            raise LeapmotorAuthError(
-                "No vehicle PIN configured. Read-only data works without a PIN, "
-                "but remote-control actions require it."
-            )
-        if action not in REMOTE_ACTION_SPECS:
-            raise LeapmotorApiError(f"Remote action not configured: {action}")
-
-        vehicle = self._find_vehicle_by_vin(vin)
-        spec = REMOTE_ACTION_SPECS[action]
-        return self._remote_control_raw(
-            vin=vehicle.vin,
-            cmd_id=spec.cmd_id,
-            cmd_content=spec.cmd_content,
-            action_label=action,
-            vehicle=vehicle,
-        )
-
-    def _remote_control_raw(
-        self,
-        *,
-        vin: str,
-        cmd_id: str,
-        cmd_content: str,
-        action_label: str,
-        vehicle: Vehicle | None = None,
-    ) -> dict[str, Any]:
-        """Execute one raw remote-control command with the verified write flow."""
-        _LOGGER.info("Starting Leapmotor remote action %s for VIN %s", action_label, vin)
-        if not self.token:
-            self.login()
-        if not self.operation_password:
-            raise LeapmotorAuthError(
-                "No vehicle PIN configured. Read-only data works without a PIN, "
-                "but remote-control actions require it."
-            )
-        if vehicle is None:
-            vehicle = self._find_vehicle_by_vin(vin)
-
-        operate_password = self._derive_operate_password(self.operation_password)
-        self._ensure_remote_cert_sync()
-
-        verify_headers = self._build_operpwd_verify_headers(vin=vin, operation_password=operate_password)
-        verify_headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        verify_body = (
-            f"operatePassword={requests.utils.quote(operate_password, safe='')}"
-            f"&vin={requests.utils.quote(vin, safe='')}"
-        )
-        verify_response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/operPwd/verify",
-            headers=verify_headers,
-            data=verify_body,
-            cert=self.account_cert,
-        )
-        _LOGGER.info(
-            "Leapmotor remote verify response for %s: HTTP %s %s",
-            action_label,
-            verify_response["status_code"],
-            verify_response["body"],
-        )
-        self._parse_api_body(verify_response["status_code"], verify_response["body"], "remote verify")
-
-        headers = self._build_remote_ctl_write_headers(
-            vin=vin,
-            cmd_content=cmd_content,
-            cmd_id=cmd_id,
-            operation_password=operate_password,
-        )
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        body = (
-            f"cmdContent={requests.utils.quote(cmd_content, safe='')}"
-            f"&vin={requests.utils.quote(vin, safe='')}"
-            f"&cmdId={requests.utils.quote(cmd_id, safe='')}"
-            f"&operatePassword={requests.utils.quote(operate_password, safe='')}"
-        )
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/app/remote/ctl",
-            headers=headers,
-            data=body,
-            cert=self.account_cert,
-        )
-        _LOGGER.info(
-            "Leapmotor remote ctl response for %s: HTTP %s %s",
-            action_label,
-            response["status_code"],
-            response["body"],
-        )
-        result = self._parse_api_body(
-            response["status_code"],
-            response["body"],
-            f"remote {action_label}",
-        )
-        remote_data = result.get("data") or {}
-        remote_ctl_id = remote_data.get("remoteCtlId")
-        if remote_ctl_id:
-            self._poll_remote_control_result(
-                vin=vehicle.vin,
-                car_id=vehicle.car_id,
-                remote_ctl_id=str(remote_ctl_id),
-                timeout_ms=int(remote_data.get("queryRemoteCtlResultTimeout") or 30000),
-                interval_ms=int(remote_data.get("queryInterval") or 2000),
-            )
-        return result
-
-    def _remote_control_without_pin_raw(
-        self,
-        *,
-        vin: str,
-        cmd_id: str,
-        cmd_content: str,
-        action_label: str,
-    ) -> dict[str, Any]:
-        """Execute a remote-control command that does not use operatePassword."""
-        _LOGGER.info("Starting Leapmotor remote action %s for VIN %s", action_label, vin)
-        if not self.token:
-            self.login()
-
-        headers = self._build_remote_ctl_write_headers_without_pin(
-            vin=vin,
-            cmd_content=cmd_content,
-            cmd_id=cmd_id,
-        )
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        body = (
-            f"cmdContent={requests.utils.quote(cmd_content, safe='')}"
-            f"&vin={requests.utils.quote(vin, safe='')}"
-            f"&cmdId={requests.utils.quote(cmd_id, safe='')}"
-        )
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/app/remote/ctl",
-            headers=headers,
-            data=body,
-            cert=self.account_cert,
-        )
-        _LOGGER.info(
-            "Leapmotor remote ctl response for %s: HTTP %s %s",
-            action_label,
-            response["status_code"],
-            response["body"],
-        )
-        return self._parse_api_body(
-            response["status_code"],
-            response["body"],
-            f"remote {action_label}",
-        )
-
-    def _ensure_remote_cert_sync(self) -> None:
-        """Bootstrap the remote-control session by syncing the account cert once."""
-        if self.remote_cert_synced:
-            return
-        headers = self._build_signed_headers()
-        headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-        response = self._post_with_curl(
-            path="/carownerservice/oversea/vehicle/v1/cert/sync",
-            headers=headers,
-            data="",
-            cert=(self.static_cert, self.static_key),
-        )
-        self._parse_api_body(response["status_code"], response["body"], "cert sync")
-        self.remote_cert_synced = True
-
-    def _poll_remote_control_result(
-        self,
-        *,
-        vin: str,
-        car_id: str | None,
-        remote_ctl_id: str,
-        timeout_ms: int,
-        interval_ms: int,
-    ) -> dict[str, Any]:
-        """Poll the remote-control result endpoint until the command finishes or times out."""
-        del vin, car_id
-        data = f"remoteCtlId={requests.utils.quote(remote_ctl_id, safe='')}"
-
-        deadline = time.monotonic() + max(timeout_ms, 1000) / 1000.0
-        last_result: dict[str, Any] | None = None
-        while time.monotonic() < deadline:
-            headers = self._build_remote_ctl_result_headers(remote_ctl_id=remote_ctl_id)
-            headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
-            response = self._post_with_curl(
-                path="/carownerservice/oversea/vehicle/v1/app/remote/ctl/result/query",
-                headers=headers,
-                data=data,
-                cert=self.account_cert,
-            )
-            last_result = self._parse_api_body(
-                response["status_code"],
-                response["body"],
-                "remote control result",
-            )
-            if (last_result.get("data")) == 1:
-                return last_result
-            sleep_seconds = max(interval_ms, 250) / 1000.0
-            if time.monotonic() + sleep_seconds >= deadline:
-                break
-            time.sleep(sleep_seconds)
-
-        raise LeapmotorApiError(f"Timed out waiting for remote control result: {last_result}")
-
-    def _find_vehicle_by_vin(self, vin: str) -> Vehicle:
-        """Resolve VIN to current vehicle metadata."""
-        for vehicle in self.get_vehicle_list():
-            if vehicle.vin == vin:
-                return vehicle
-        raise LeapmotorApiError(f"Vehicle not found for VIN {vin}")
-
-    def _derive_operate_password(self, pin: str) -> str:
-        """Derive operatePassword from the vehicle PIN using the current session token."""
-        key_text, iv_text = self._derive_operpwd_key_iv()
-        padder = padding.PKCS7(128).padder()
-        padded = padder.update(pin.encode("utf-8")) + padder.finalize()
-        cipher = Cipher(
-            algorithms.AES(key_text.encode("utf-8")),
-            modes.CBC(iv_text.encode("utf-8")),
-        )
-        encryptor = cipher.encryptor()
-        ciphertext = encryptor.update(padded) + encryptor.finalize()
-        return base64.b64encode(ciphertext).decode("ascii")
-
-    def _derive_operpwd_key_iv(self) -> tuple[str, str]:
-        """Mirror MD5Util.getEncryptPassword with token-derived AES key/IV."""
-        if not self.token:
-            return DEFAULT_OPERPWD_AES_KEY, DEFAULT_OPERPWD_AES_IV
-        if len(self.token) < 64:
-            raise LeapmotorAuthError("Access token is too short for operatePassword derivation.")
-        key_source = self.token[:32]
-        iv_source = self.token[32:64]
-        key_text = hashlib.md5(key_source.encode("utf-8")).hexdigest()[8:24]
-        iv_text = hashlib.md5(iv_source.encode("utf-8")).hexdigest()[8:24]
-        return key_text, iv_text
-
-    @staticmethod
-    def _derive_session_device_id(token: str | None) -> str:
-        """Extract the session deviceId from the JWT payload."""
-        if not token:
-            return DEFAULT_DEVICE_ID
-        try:
-            payload_b64 = token.split(".")[1]
-            payload_b64 += "=" * (-len(payload_b64) % 4)
-            payload = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")))
-            user_name = str(payload.get("user_name") or "")
-            parts = user_name.split(",")
-            if len(parts) >= 4 and parts[2]:
-                return parts[2]
-        except Exception:  # noqa: BLE001
-            pass
-        return DEFAULT_DEVICE_ID
-
-    def _load_account_cert(self, login_data: dict[str, Any]) -> None:
-        base64_cert = str(login_data.get("base64Cert", ""))
-        p12_bytes = base64.b64decode(base64_cert)
-        candidates: list[tuple[str, str]] = []
-        if self.account_p12_password:
-            candidates.append(("provided", self.account_p12_password))
-        try:
-            derived_password = derive_account_p12_password(login_data["id"], str(login_data["uid"]))
-        except (KeyError, TypeError, ValueError):
-            derived_password = None
-        if derived_password and all(password != derived_password for _, password in candidates):
-            candidates.append(("derived", derived_password))
-        candidates.extend(
-            ("fallback", password)
-            for password in KNOWN_ACCOUNT_P12_PASSWORDS
-            if all(candidate != password for _, candidate in candidates)
-        )
-
-        last_error: Exception | None = None
-        for source, password in candidates:
-            try:
-                key, cert, _additional = pkcs12.load_key_and_certificates(
-                    p12_bytes,
-                    password.encode("utf-8"),
-                )
-            except Exception as exc:  # noqa: BLE001
-                last_error = exc
-                continue
-            if key is None or cert is None:
-                continue
-
-            cert_file = tempfile.NamedTemporaryFile(delete=False, suffix="-leapmotor-cert.pem")
-            key_file = tempfile.NamedTemporaryFile(delete=False, suffix="-leapmotor-key.pem")
-            cert_file.write(cert.public_bytes(serialization.Encoding.PEM))
-            key_file.write(
-                key.private_bytes(
-                    serialization.Encoding.PEM,
-                    serialization.PrivateFormat.TraditionalOpenSSL,
-                    serialization.NoEncryption(),
-                )
-            )
-            cert_file.close()
-            key_file.close()
-            self.account_cert_file = cert_file.name
-            self.account_key_file = key_file.name
-            self.account_p12_password_used = password
-            self.account_p12_password_source = source
-            return
-
-        raise LeapmotorAccountCertError(f"Could not open account certificate: {last_error}")
-
-    def _build_login_form_body(self) -> str:
-        return (
-            "isRecoverAcct=0"
-            f"&password={requests.utils.quote(self.password, safe='')}"
-            "&policyId=20260204"
-            "&loginMethod=1"
-            f"&email={requests.utils.quote(self.username, safe='')}"
-        )
-
-    def _build_login_headers(self) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = "".join(
-            [
-                DEFAULT_LANGUAGE,
-                DEFAULT_DEVICE_TYPE,
-                self.device_id,
-                "1",
-                self.username,
-                "0",
-                "1",
-                nonce,
-                self.password,
-                "20260204",
-                DEFAULT_SOURCE,
-                timestamp,
-                DEFAULT_APP_VERSION,
-            ]
-        )
-        return {
-            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hashlib.sha256(sign_input.encode("utf-8")).hexdigest(),
-        }
-
-    def _build_signed_headers(self, *, vin: str | None = None) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input_parts = [
-            DEFAULT_LANGUAGE,
-            DEFAULT_CHANNEL,
-            self.device_id,
-            DEFAULT_DEVICE_TYPE,
-            nonce,
-            DEFAULT_SOURCE,
-            timestamp,
-            DEFAULT_APP_VERSION,
-        ]
-        if vin:
-            sign_input_parts.append(vin)
-        sign_input = "".join(sign_input_parts)
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_consumption_weekly_rank_headers(self, *, carvin: str) -> dict[str, str]:
-        """Build the signature variant used by getLastNweeks100kmECAndRank."""
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = "".join(
-            [
-                DEFAULT_LANGUAGE,
-                carvin,
-                DEFAULT_CHANNEL,
-                self.device_id,
-                DEFAULT_DEVICE_TYPE,
-                nonce,
-                DEFAULT_SOURCE,
-                timestamp,
-                DEFAULT_APP_VERSION,
-            ]
-        )
-        return self._signed_header_dict(nonce=nonce, timestamp=timestamp, sign_input=sign_input)
-
-    def _build_mileage_energy_detail_headers(
-        self,
-        *,
-        vin: str,
-        begintime: str,
-        endtime: str,
-    ) -> dict[str, str]:
-        """Build the signature variant used by mileage/energy/detail with date range."""
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = "".join(
-            [
-                DEFAULT_LANGUAGE,
-                begintime,
-                DEFAULT_CHANNEL,
-                self.device_id,
-                DEFAULT_DEVICE_TYPE,
-                endtime,
-                nonce,
-                DEFAULT_SOURCE,
-                timestamp,
-                DEFAULT_APP_VERSION,
-                vin,
-            ]
-        )
-        return self._signed_header_dict(nonce=nonce, timestamp=timestamp, sign_input=sign_input)
-
-    def _build_consumption_last_week_headers(
-        self,
-        *,
-        carvin: str,
-        begintime: str,
-        endtime: str,
-    ) -> dict[str, str]:
-        """Build the signature variant used by getLastweekEC."""
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = "".join(
-            [
-                DEFAULT_LANGUAGE,
-                begintime,
-                carvin,
-                DEFAULT_CHANNEL,
-                self.device_id,
-                DEFAULT_DEVICE_TYPE,
-                endtime,
-                nonce,
-                DEFAULT_SOURCE,
-                timestamp,
-                DEFAULT_APP_VERSION,
-            ]
-        )
-        return self._signed_header_dict(nonce=nonce, timestamp=timestamp, sign_input=sign_input)
-
-    def _signed_header_dict(
-        self,
-        *,
-        nonce: str,
-        timestamp: str,
-        sign_input: str,
-    ) -> dict[str, str]:
-        """Return common signed app headers for account-certificate requests."""
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_car_picture_headers(self, *, vin: str) -> dict[str, str]:
-        """Build the signature variant used by vehicle/v1/carpicture/key."""
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{self.device_id}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{nonce}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-            f"{vin}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_car_picture_package_headers(self, *, picture_key: str) -> dict[str, str]:
-        """Build the signature variant used by vehicle/v1/carpicture/package."""
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{picture_key}"
-            f"{nonce}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_operpwd_verify_headers(self, *, vin: str, operation_password: str) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{nonce}"
-            f"{operation_password}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-            f"{vin}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_remote_ctl_write_headers(
-        self,
-        *,
-        vin: str,
-        cmd_content: str,
-        cmd_id: str,
-        operation_password: str,
-    ) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{cmd_content}"
-            f"{cmd_id}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{nonce}"
-            f"{operation_password}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-            f"{vin}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_remote_ctl_write_headers_without_pin(
-        self,
-        *,
-        vin: str,
-        cmd_content: str,
-        cmd_id: str,
-    ) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{cmd_content}"
-            f"{cmd_id}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{nonce}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-            f"{vin}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _build_remote_ctl_result_headers(self, *, remote_ctl_id: str) -> dict[str, str]:
-        nonce = str(random.randint(100000, 9999999))
-        timestamp = str(int(time.time() * 1000))
-        sign_input = (
-            f"{DEFAULT_LANGUAGE}"
-            f"{DEFAULT_CHANNEL}"
-            f"{self.device_id}"
-            f"{DEFAULT_DEVICE_TYPE}"
-            f"{nonce}"
-            f"{remote_ctl_id}"
-            f"{DEFAULT_SOURCE}"
-            f"{timestamp}"
-            f"{DEFAULT_APP_VERSION}"
-        )
-        return {
-            "acceptLanguage": DEFAULT_LANGUAGE,
-            "channel": DEFAULT_CHANNEL,
-            "deviceType": DEFAULT_DEVICE_TYPE,
-            "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
-            "source": DEFAULT_SOURCE,
-            "version": DEFAULT_APP_VERSION,
-            "nonce": nonce,
-            "deviceId": self.device_id,
-            "timestamp": timestamp,
-            "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
-        }
-
-    def _auth_headers(self, *, content_type: str) -> dict[str, str]:
-        if not self.user_id or not self.token:
-            raise LeapmotorAuthError("Not authenticated.")
-        return {
-            "Content-Type": content_type,
-            "userId": self.user_id,
-            "token": self.token,
-        }
-
-    def _parse_api_body(self, status_code: int, body: str, label: str) -> dict[str, Any]:
-        try:
-            data = json.loads(body)
-        except ValueError as exc:
-            self._record_api_result(label, status_code=status_code, code=None, message="non_json")
-            raise LeapmotorApiError(f"{label} returned non-JSON response: {body[:200]}") from exc
-        self._record_api_result(
-            label,
-            status_code=status_code,
-            code=data.get("code"),
-            message=data.get("message"),
-        )
-        if status_code != 200 or data.get("code") != 0:
-            message = data.get("message") or body[:200]
-            if label == "login":
-                raise LeapmotorAuthError(f"Leapmotor login failed: {message}")
-            if label == "remote verify":
-                raise LeapmotorAuthError(
-                    "Leapmotor remote verify failed: "
-                    f"{message}. The backend currently rejects the verification "
-                    "request before any vehicle action is sent."
-                )
-            raise LeapmotorApiError(f"Leapmotor {label} failed: {message}")
-        return data
-
-    def _record_api_result(
-        self,
-        label: str,
-        *,
-        status_code: int,
-        code: Any,
-        message: Any,
-    ) -> None:
-        """Store compact API result metadata for diagnostics."""
-        self.last_api_results[label] = {
-            "http_status": status_code,
-            "code": code,
-            "message": message,
-            "updated_at": time.time(),
-        }
-
-    def _post_with_curl(
-        self,
-        *,
-        path: str,
-        headers: dict[str, str],
-        data: str,
-        cert: tuple[str, str],
-    ) -> dict[str, Any]:
-        """Send a POST with curl, matching the verified reverse-engineered client."""
-        url = f"{self.base_url}/{path.lstrip('/')}"
-        with tempfile.NamedTemporaryFile() as header_file, tempfile.NamedTemporaryFile() as body_file:
-            cmd = [
-                "curl",
-                "--silent",
-                "--show-error",
-                "--insecure",
-                "-X",
-                "POST",
-                url,
-                "-D",
-                header_file.name,
-                "-o",
-                body_file.name,
-                "--cert",
-                cert[0],
-                "--key",
-                cert[1],
-            ]
-            for key, value in headers.items():
-                cmd.extend(["-H", f"{key}: {value}"])
-            cmd.extend(["--data", data])
-
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            body_text = Path(body_file.name).read_text(encoding="utf-8", errors="replace")
-            header_text = Path(header_file.name).read_text(encoding="utf-8", errors="replace")
-            if result.returncode != 0:
-                raise LeapmotorApiError(f"curl request failed: {result.stderr.strip()}")
-
-        status_code = 0
-        for line in header_text.splitlines():
-            if line.startswith("HTTP/"):
-                parts = line.split()
-                if len(parts) >= 2 and parts[1].isdigit():
-                    status_code = int(parts[1])
-        return {"status_code": status_code, "body": body_text, "headers": header_text}
-
-    def _post_binary_with_curl(
-        self,
-        *,
-        path: str,
-        headers: dict[str, str],
-        data: str,
-        cert: tuple[str, str],
-    ) -> dict[str, Any]:
-        """Send a POST with curl and return the raw response body bytes."""
-        url = f"{self.base_url}/{path.lstrip('/')}"
-        with tempfile.NamedTemporaryFile() as header_file, tempfile.NamedTemporaryFile() as body_file:
-            cmd = [
-                "curl",
-                "--silent",
-                "--show-error",
-                "--insecure",
-                "-X",
-                "POST",
-                url,
-                "-D",
-                header_file.name,
-                "-o",
-                body_file.name,
-                "--cert",
-                cert[0],
-                "--key",
-                cert[1],
-            ]
-            for key, value in headers.items():
-                cmd.extend(["-H", f"{key}: {value}"])
-            cmd.extend(["--data", data])
-
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-            body_bytes = Path(body_file.name).read_bytes()
-            header_text = Path(header_file.name).read_text(encoding="utf-8", errors="replace")
-            if result.returncode != 0:
-                raise LeapmotorApiError(f"curl request failed: {result.stderr.strip()}")
-
-        status_code = 0
-        for line in header_text.splitlines():
-            if line.startswith("HTTP/"):
-                parts = line.split()
-                if len(parts) >= 2 and parts[1].isdigit():
-                    status_code = int(parts[1])
-        return {"status_code": status_code, "body": body_bytes, "headers": header_text}
+def _build_signed_headers(
+    sign_key: bytes,
+    device_id: str,
+    nonce: str,
+    timestamp: str,
+    sign_input: str,
+) -> dict[str, str]:
+    return {
+        "acceptLanguage": DEFAULT_LANGUAGE,
+        "channel": DEFAULT_CHANNEL,
+        "deviceType": DEFAULT_DEVICE_TYPE,
+        "X-P12_ENC_ALG": DEFAULT_P12_ENC_ALG,
+        "source": DEFAULT_SOURCE,
+        "version": DEFAULT_APP_VERSION,
+        "nonce": nonce,
+        "deviceId": device_id,
+        "timestamp": timestamp,
+        "sign": hmac.new(sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
+    }
 
 
-def normalize_vehicle(
-    vehicle: Vehicle,
-    status_json: dict[str, Any],
-    user_id: str | None,
-    *,
-    mileage_json: dict[str, Any] | None = None,
-    consumption_rank_json: dict[str, Any] | None = None,
-    consumption_breakdown_json: dict[str, Any] | None = None,
-    picture_json: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Normalize Leapmotor status payload into Home Assistant-friendly values."""
-    status_data = status_json.get("data") or {}
-    signal = status_data.get("signal") or {}
-    config = status_data.get("config") or {}
-    charge_plan = config.get("3") or {}
+def _augment_history(
+    history: dict[str, Any],
+    mileage_json: dict[str, Any] | None,
+    rank_json: dict[str, Any] | None,
+    breakdown_json: dict[str, Any] | None,
+) -> None:
+    """Add consumption + extended mileage fields to the history dict in-place."""
     mileage_data = (mileage_json or {}).get("data") or {}
-    rank_data = (consumption_rank_json or {}).get("data") or {}
+    rank_data = (rank_json or {}).get("data") or {}
     rank_result = rank_data.get("rankResult") or {}
     weekly_ec = rank_data.get("weeklyEC") or []
-    breakdown_data = (consumption_breakdown_json or {}).get("data") or {}
-    picture_data = (picture_json or {}).get("data") or {}
-    vehicle_state = _derive_vehicle_state(signal)
-    tire_pressures = _tire_pressures_bar(vehicle.car_type, signal)
+    breakdown_data = (breakdown_json or {}).get("data") or {}
     last_7_days_energy = _sum_detail_field(mileage_data.get("detail"), "accumulatedEnergyConsume")
     last_week_split = _energy_breakdown_percentages(breakdown_data)
+    history.update({
+        "total_energy_kwh": _safe_float(mileage_data.get("totalEnergy")),
+        "last_7_days_mileage_km": mileage_data.get("totalAccumulatedMileage"),
+        "last_7_days_mileage_mi": _safe_float(mileage_data.get("totalAccumulatedMileageMile")),
+        "last_7_days_energy_kwh": last_7_days_energy,
+        "average_consumption_6w_kwh_100km": _safe_float(rank_result.get("hundredKmEC")),
+        "average_consumption_6w_mi_kwh": _safe_float(rank_result.get("hundredMiKwhEC")),
+        "consumption_rank": rank_result.get("rank"),
+        "weekly_consumption": weekly_ec,
+        "last_week_driving_energy_kwh": _safe_float(breakdown_data.get("driverEC")),
+        "last_week_climate_energy_kwh": _safe_float(breakdown_data.get("acEC")),
+        "last_week_other_energy_kwh": _safe_float(breakdown_data.get("otherEC")),
+        "last_week_driving_energy_percent": last_week_split.get("driving"),
+        "last_week_climate_energy_percent": last_week_split.get("climate"),
+        "last_week_other_energy_percent": last_week_split.get("other"),
+    })
 
-    return {
-        "vehicle": {
-            "vin": vehicle.vin,
-            "user_id": user_id,
-            "car_id": vehicle.car_id,
-            "car_type": vehicle.car_type,
-            "nickname": vehicle.nickname,
-            "is_shared": vehicle.is_shared,
-            "year": vehicle.year,
-            "rights": vehicle.rights,
-            "abilities": vehicle.abilities or [],
-            "module_rights": vehicle.module_rights,
-        },
-        "status": {
-            "battery_percent": signal.get("1204"),
-            "remaining_range_km": signal.get("3260"),
-            "odometer_km": signal.get("1318"),
-            "battery_percent_precise": _safe_float(signal.get("100003")),
-            "wltp_max_range_km": _safe_int(signal.get("3257")),
-            "is_locked": _is_locked(signal),
-            "raw_lock_status_code": signal.get("1298"),
-            "lock_state_source": "raw_signal_1298",
-            "is_parked": vehicle_state == "parked" if vehicle_state is not None else None,
-            "vehicle_state": vehicle_state,
-            "vehicle_state_source": "raw_signal",
-            "raw_charge_status_code": signal.get("1939"),
-            "raw_charge_connection_code": signal.get("1149"),
-            "raw_drive_status_code": signal.get("1941"),
-            "raw_vehicle_state_code": signal.get("1944"),
-            "raw_parked_status_code": signal.get("1298"),
-            "interior_temp_c": signal.get("1349"),
-            "climate_set_temp_left_c": signal.get("2183"),
-            "climate_set_temp_right_c": signal.get("2184"),
-            "last_vehicle_timestamp": signal.get("sts"),
-        },
-        "location": {
-            "latitude": signal.get("3725", signal.get("2190")),
-            "longitude": signal.get("3724", signal.get("2191")),
-            "privacy_gps": status_data.get("privacyGPS"),
-            "privacy_data": status_data.get("privacyData"),
-            "last_vehicle_timestamp": signal.get("sts"),
-        },
-        "charging": {
-            "is_charging": _is_charging(signal),
-            "is_plugged_in": _is_plugged_in(signal),
-            "connection_state": _charging_connection_state(signal),
-            "charge_limit_percent": charge_plan.get("percent"),
-            "remaining_charge_minutes": _safe_int(signal.get("1200")),
-            "charging_power_kw": _charging_power_kw(signal),
-            "charging_current_a": _safe_float(signal.get("1178")),
-            "charging_voltage_v": _safe_float(signal.get("1177")),
-            "charging_planned_enabled": charge_plan.get("isEnable"),
-            "charging_planned_start": charge_plan.get("beginTime"),
-            "charging_planned_end": charge_plan.get("endTime"),
-            "charging_planned_cycles": charge_plan.get("cycles"),
-            "charging_planned_circulation": charge_plan.get("circulation"),
-            "charging_plan_updated_at": charge_plan.get("updateTime"),
-        },
-        "history": {
-            "total_mileage_km": mileage_data.get("totalmileage"),
-            "total_mileage_mi": _safe_float(mileage_data.get("totalmileageMile")),
-            "delivery_days": mileage_data.get("deliveryDays"),
-            "total_energy_kwh": _safe_float(mileage_data.get("totalEnergy")),
-            "last_7_days_mileage_km": mileage_data.get("totalAccumulatedMileage"),
-            "last_7_days_mileage_mi": _safe_float(mileage_data.get("totalAccumulatedMileageMile")),
-            "last_7_days_energy_kwh": last_7_days_energy,
-            "average_consumption_6w_kwh_100km": _safe_float(rank_result.get("hundredKmEC")),
-            "average_consumption_6w_mi_kwh": _safe_float(rank_result.get("hundredMiKwhEC")),
-            "consumption_rank": rank_result.get("rank"),
-            "weekly_consumption": weekly_ec,
-            "last_week_driving_energy_kwh": _safe_float(breakdown_data.get("driverEC")),
-            "last_week_climate_energy_kwh": _safe_float(breakdown_data.get("acEC")),
-            "last_week_other_energy_kwh": _safe_float(breakdown_data.get("otherEC")),
-            "last_week_driving_energy_percent": last_week_split.get("driving"),
-            "last_week_climate_energy_percent": last_week_split.get("climate"),
-            "last_week_other_energy_percent": last_week_split.get("other"),
-        },
-        "media": {
-            "car_picture_status": "available" if picture_data.get("key") else "unavailable",
-            "car_picture_url": picture_data.get("shareBindUrl"),
-            "car_picture_key": picture_data.get("key"),
-            "car_picture_whole": picture_data.get("whole"),
-            "car_picture_key_present": bool(picture_data.get("key")),
-            "car_picture_whole_present": bool(picture_data.get("whole")),
-        },
-        "diagnostics": {
-            **tire_pressures,
-            "charge_plug_signal": signal.get("47"),
-            "raw_signal_47": signal.get("47"),
-            "raw_signal_1149": signal.get("1149"),
-            "remote_session_active": _one_is_on(signal.get("1256")) or _one_is_on(signal.get("1257")),
-            "driver_door_open": _one_is_on(signal.get("1277")),
-            "passenger_door_open": _one_is_on(signal.get("1278")),
-            "rear_left_door_open": _one_is_on(signal.get("1279")),
-            "rear_right_door_open": _one_is_on(signal.get("1280")),
-            "trunk_open": _one_is_on(signal.get("1281")),
-            "climate_on": _one_is_on(signal.get("1938")),
-            "climate_mode": _climate_mode(signal),
-            "fast_cooling_active": _two_is_on(signal.get("2669")),
-            "fast_heating_active": _two_is_on(signal.get("2681")),
-            "windshield_defrosting": _two_is_on(signal.get("1945")),
-            "rear_window_heating": _one_is_on(signal.get("1946")),
-            "steering_wheel_heating": _two_is_on(signal.get("1816")),
-            "steering_wheel_heating_remaining_minutes": _safe_int(signal.get("1624")),
-            "driver_seat_heating_level": _safe_int(signal.get("2100")),
-            "passenger_seat_heating_level": _safe_int(signal.get("2118")),
-            "driver_seat_ventilation_level": _safe_int(signal.get("2101")),
-            "passenger_seat_ventilation_level": _safe_int(signal.get("2119")),
-            "left_mirror_heating": _one_is_on(signal.get("49")),
-            "right_mirror_heating": _one_is_on(signal.get("50")),
-            "speed_limit_enabled": _one_is_on(signal.get("6047")),
-            "speed_limit_kmh": _safe_int(signal.get("6048")),
-            "raw_signal_1256": signal.get("1256"),
-            "raw_signal_1257": signal.get("1257"),
-            "raw_signal_1258": signal.get("1258"),
-            "raw_signal_1277": signal.get("1277"),
-            "raw_signal_1278": signal.get("1278"),
-            "raw_signal_1279": signal.get("1279"),
-            "raw_signal_1280": signal.get("1280"),
-            "raw_signal_1281": signal.get("1281"),
-            "raw_signal_1693": signal.get("1693"),
-            "raw_signal_1694": signal.get("1694"),
-            "raw_signal_1695": signal.get("1695"),
-            "raw_signal_1696": signal.get("1696"),
-            "raw_signal_1816": signal.get("1816"),
-            "raw_signal_1938": signal.get("1938"),
-            "raw_signal_1939": signal.get("1939"),
-            "raw_signal_1943": signal.get("1943"),
-            "raw_signal_1945": signal.get("1945"),
-            "raw_signal_1946": signal.get("1946"),
-            "raw_signal_2100": signal.get("2100"),
-            "raw_signal_2101": signal.get("2101"),
-            "raw_signal_2118": signal.get("2118"),
-            "raw_signal_2119": signal.get("2119"),
-            "raw_signal_2188": signal.get("2188"),
-            "raw_signal_2669": signal.get("2669"),
-            "raw_signal_2681": signal.get("2681"),
-            "raw_signal_3710": signal.get("3710"),
-            "raw_signal_3712": signal.get("3712"),
-            "raw_signal_3713": signal.get("3713"),
-            "raw_signal_3257": signal.get("3257"),
-            "raw_signal_6047": signal.get("6047"),
-            "raw_signal_6048": signal.get("6048"),
-            "raw_signal_100003": signal.get("100003"),
-            "raw_signal_100010": signal.get("100010"),
-            "raw_signal_100011": signal.get("100011"),
-            "raw_signal_100012": signal.get("100012"),
-            "raw_signal_100013": signal.get("100013"),
-            "raw_signal_100014": signal.get("100014"),
-            "raw_signal_100015": signal.get("100015"),
-            "raw_signal_100016": signal.get("100016"),
-            "raw_signal_100017": signal.get("100017"),
-        },
-        "raw_updated_at": time.time(),
+
+def _augment_status(status: dict[str, Any], status_json: dict[str, Any]) -> None:
+    """Correct is_locked: markoceri uses signal 47 (wrong); validated signal is 1298."""
+    signal = (status_json.get("data") or {}).get("signal") or {}
+    lock_raw = _safe_int(signal.get("1298"))
+    if lock_raw is not None:
+        status["is_locked"] = lock_raw == 1
+        status["raw_lock_status_code"] = lock_raw
+        status["lock_state_source"] = "raw_signal_1298"
+
+
+def _augment_charging(charging: dict[str, Any], status_json: dict[str, Any]) -> None:
+    """Add is_plugged_in and is_regening to the charging dict."""
+    signal = (status_json.get("data") or {}).get("signal") or {}
+    # Signal 47 = charge cable physically plugged in (1=yes); fallback to 1149
+    is_plugged_in: bool | None = None
+    plug = _safe_int(signal.get("47"))
+    if plug is not None:
+        is_plugged_in = plug == 1
+    else:
+        conn = _safe_int(signal.get("1149"))
+        if conn is not None:
+            is_plugged_in = conn in (1, 2)
+    # is_regening: charging power flowing while NOT connected to external charger
+    is_regening: bool | None = None
+    charging_power_kw = charging.get("charging_power_kw")
+    if charging_power_kw is not None and is_plugged_in is not None:
+        is_regening = not is_plugged_in and charging_power_kw > 0
+    charging["is_plugged_in"] = is_plugged_in
+    charging["is_regening"] = is_regening
+
+
+def _augment_windows(vehicle_data: dict[str, Any], status_json: dict[str, Any]) -> None:
+    """Add window and sunshade positions to vehicle_data."""
+    status_data = status_json.get("data") or {}
+    vehicle_data["windows"] = {
+        "left_front_percent": status_data.get("leftFrontWindowPercent"),
+        "right_front_percent": status_data.get("rightFrontWindowPercent"),
+        "left_rear_percent": status_data.get("leftRearWindowPercent"),
+        "right_rear_percent": status_data.get("rightRearWindowPercent"),
+        "sun_shade": status_data.get("sunShade"),
     }
-
-
-def _vehicle_status_car_type_path(car_type: str | None) -> str:
-    """Return the backend status path segment for a vehicle model."""
-    normalized = str(car_type or "C10").strip().lower()
-    if normalized == "b10":
-        # The international backend reports carType=B10 in the vehicle list,
-        # but the status endpoint is shared with C10.
-        return "c10"
-    return normalized or "c10"
-
-
-def _tire_pressures_bar(car_type: str | None, signal: dict[str, Any]) -> dict[str, float | None]:
-    """Return model-specific tire-pressure slot mapping."""
-    if str(car_type or "").strip().upper() == "B10":
-        return {
-            "tire_pressure_front_left_bar": _to_bar(signal.get("2646")),
-            "tire_pressure_front_right_bar": _to_bar(signal.get("2653")),
-            "tire_pressure_rear_left_bar": _to_bar(signal.get("2660")),
-            "tire_pressure_rear_right_bar": _to_bar(signal.get("2667")),
-        }
-    return {
-        "tire_pressure_front_left_bar": _to_bar(signal.get("2667")),
-        "tire_pressure_front_right_bar": _to_bar(signal.get("2653")),
-        "tire_pressure_rear_left_bar": _to_bar(signal.get("2646")),
-        "tire_pressure_rear_right_bar": _to_bar(signal.get("2660")),
-    }
-
-
-def _last_seven_day_window_ms() -> tuple[int, int]:
-    """Return the local app-style window used for 7-day mileage/energy detail."""
-    now = _berlin_now()
-    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    start = today - timedelta(days=7)
-    end = today + timedelta(days=1) - timedelta(seconds=1)
-    return int(start.timestamp() * 1000), int(end.timestamp() * 1000)
 
 
 def _previous_week_window_seconds() -> tuple[int, int]:
-    """Return the previous Monday-Sunday window used by getLastweekEC."""
     now = _berlin_now()
-    this_monday = (now - timedelta(days=now.weekday())).replace(
-        hour=0,
-        minute=0,
-        second=0,
-        microsecond=0,
-    )
+    this_monday = (now - timedelta(days=now.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
     start = this_monday - timedelta(days=7)
     end = this_monday - timedelta(seconds=1)
     return int(start.timestamp()), int(end.timestamp())
 
 
 def _berlin_now() -> datetime:
-    """Return current time in the locale observed in the app traces."""
     try:
         return datetime.now(ZoneInfo("Europe/Berlin"))
     except Exception:
@@ -1623,7 +276,6 @@ def _berlin_now() -> datetime:
 
 
 def _sum_detail_field(detail: Any, field: str) -> float | None:
-    """Sum one numeric field from an API detail list."""
     if not isinstance(detail, list):
         return None
     total = 0.0
@@ -1640,18 +292,28 @@ def _sum_detail_field(detail: Any, field: str) -> float | None:
 
 
 def _energy_breakdown_percentages(data: dict[str, Any]) -> dict[str, float | None]:
-    """Convert last-week kWh split values to percentages."""
     values = {
         "driving": _safe_float(data.get("driverEC")),
         "climate": _safe_float(data.get("acEC")),
         "other": _safe_float(data.get("otherEC")),
     }
-    total = sum(value for value in values.values() if value is not None)
+    total = sum(v for v in values.values() if v is not None)
     if total <= 0:
-        return {key: None for key in values}
+        return {k: None for k in values}
+    return {k: round(v * 100 / total, 1) if v is not None else None for k, v in values.items()}
+
+
+def _build_messages_dict(vin: str, messages: list[Any] | None) -> dict[str, Any]:
+    """Build per-vehicle message summary dict."""
+    if messages is None:
+        return {"unread_count": None, "last_title": None, "last_send_time": None}
+    vehicle_msgs = [m for m in messages if m.vin == vin or m.vin is None]
+    unread = sum(1 for m in vehicle_msgs if not m.is_read)
+    latest = max(vehicle_msgs, key=lambda m: m.send_time or 0, default=None)
     return {
-        key: round(value * 100 / total, 1) if value is not None else None
-        for key, value in values.items()
+        "unread_count": unread,
+        "last_title": latest.title if latest else None,
+        "last_send_time": latest.send_time if latest else None,
     }
 
 
@@ -1671,127 +333,3 @@ def _safe_float(raw: Any) -> float | None:
         return float(raw)
     except (TypeError, ValueError):
         return None
-
-
-def _to_bar(raw: Any) -> float | None:
-    if raw is None:
-        return None
-    try:
-        return round(float(raw) / 100.0, 2)
-    except (TypeError, ValueError):
-        return None
-
-
-def _one_is_on(raw: Any) -> bool | None:
-    value = _safe_int(raw)
-    if value is None:
-        return None
-    return value == 1
-
-
-def _two_is_on(raw: Any) -> bool | None:
-    value = _safe_int(raw)
-    if value is None:
-        return None
-    return value == 2
-
-
-def _derive_vehicle_state(signal: dict[str, Any]) -> str | None:
-    """Return the movement state independent from charging state."""
-    drive_status = _safe_int(signal.get("1941"))
-    vehicle_state = _safe_int(signal.get("1944"))
-    if drive_status in (1, 2, 4, 7) or vehicle_state in (1, 2, 4):
-        return "parked"
-    if drive_status in (3, 5) or vehicle_state in (5,):
-        return "driving"
-
-    return None
-
-
-def _is_locked(signal: dict[str, Any]) -> bool | None:
-    """Return app-correlated door-lock state from the validated home-screen signal."""
-    lock_status = _safe_int(signal.get("1298"))
-    if lock_status is None:
-        return None
-    if lock_status == 1:
-        return True
-    if lock_status == 0:
-        return False
-    return None
-
-
-def _is_charging(signal: dict[str, Any]) -> bool:
-    """Return whether the vehicle is currently charging."""
-    connection_status = _safe_int(signal.get("1149"))
-    if connection_status == 2:
-        return True
-    if connection_status in (0, 1):
-        return False
-
-    remaining_charge_minutes = _safe_int(signal.get("1200"))
-    charging_current_a = _safe_float(signal.get("1178"))
-    if charging_current_a is not None and remaining_charge_minutes is not None:
-        # Confirmed charging sessions show a clearly non-zero current
-        # (typically negative while energy flows into the pack). Treat
-        # sub-1A noise as idle / just plugged in.
-        return abs(charging_current_a) >= 1.0
-
-    charging_power_kw = _charging_power_kw(signal)
-    if charging_power_kw is not None:
-        return charging_power_kw >= 1.0 and remaining_charge_minutes is not None
-
-    charge_status = _safe_int(signal.get("1939"))
-    drive_status = _safe_int(signal.get("1941"))
-    vehicle_state = _safe_int(signal.get("1944"))
-
-    # `1939` alone is too noisy and can remain non-zero outside active charging.
-    # Only trust it as a last fallback when a remaining charge time is present
-    # and secondary state fields line up with an active charge session.
-    return charge_status in (1, 2, 3) and (
-        remaining_charge_minutes is not None and (drive_status == 2 or vehicle_state == 0)
-    )
-
-
-def _is_plugged_in(signal: dict[str, Any]) -> bool | None:
-    """Return whether the charge cable is plugged in."""
-    plug = _safe_int(signal.get("47"))
-    if plug is not None:
-        return plug == 1
-    connection_status = _safe_int(signal.get("1149"))
-    if connection_status is not None:
-        return connection_status in (1, 2)
-    return None
-
-
-def _charging_connection_state(signal: dict[str, Any]) -> str | None:
-    """Return the observed charge-connection state."""
-    connection_status = _safe_int(signal.get("1149"))
-    if connection_status == 0:
-        return "unplugged"
-    if connection_status == 1:
-        return "connecting"
-    if connection_status == 2:
-        return "charging"
-    return None
-
-
-def _climate_mode(signal: dict[str, Any]) -> str | None:
-    mode = _safe_int(signal.get("3713"))
-    return {
-        0: "off",
-        1: "fast_cool",
-        3: "fast_heat",
-        4: "quick_ventilation",
-    }.get(mode)
-
-
-def _charging_power_kw(signal: dict[str, Any]) -> float | None:
-    """Return charging power without using GPS longitude-like signal 2191."""
-    current = _safe_float(signal.get("1178"))
-    voltage = _safe_float(signal.get("1177"))
-    if current is None or voltage is None:
-        return None
-    # The C10 plugged-idle snapshot shows about 1.5A without active charging.
-    if abs(current) < 3.0:
-        return None
-    return round(abs(current * voltage) / 1000.0, 3)

--- a/custom_components/leapmotor/binary_sensor.py
+++ b/custom_components/leapmotor/binary_sensor.py
@@ -156,6 +156,12 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[LeapmotorBinarySensorEntityDescription, ...] =
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data["diagnostics"].get("speed_limit_enabled"),
     ),
+    LeapmotorBinarySensorEntityDescription(
+        key="is_regening",
+        translation_key="is_regening",
+        icon="mdi:car-electric",
+        value_fn=lambda data: data["charging"].get("is_regening"),
+    ),
 )
 
 

--- a/custom_components/leapmotor/diagnostics.py
+++ b/custom_components/leapmotor/diagnostics.py
@@ -51,7 +51,7 @@ async def async_get_config_entry_diagnostics(
                     "vin": _redact_vin(vin),
                     "car_id": vehicle.get("car_id"),
                     "car_type": vehicle.get("car_type"),
-                    "nickname": vehicle.get("nickname"),
+                    "nickname": vehicle.get("vehicle_nickname") or vehicle.get("nickname"),
                     "is_shared": vehicle.get("is_shared"),
                     "year": vehicle.get("year"),
                     "rights": vehicle.get("rights"),

--- a/custom_components/leapmotor/entity_helpers.py
+++ b/custom_components/leapmotor/entity_helpers.py
@@ -7,7 +7,7 @@ from typing import Any
 
 def build_vehicle_display_name(vehicle: dict[str, Any]) -> str:
     """Return a stable, user-friendly vehicle device name."""
-    nickname = vehicle.get("nickname")
+    nickname = vehicle.get("vehicle_nickname") or vehicle.get("nickname")
     car_type = vehicle.get("car_type") or "Vehicle"
     year = vehicle.get("year")
     is_shared = vehicle.get("is_shared")

--- a/custom_components/leapmotor/manifest.json
+++ b/custom_components/leapmotor/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/kerniger/leapmotor-ha",
   "issue_tracker": "https://github.com/kerniger/leapmotor-ha/issues",
   "iot_class": "cloud_polling",
-  "requirements": ["cryptography>=42.0.0", "requests>=2.31.0"],
-  "version": "0.5.20"
+  "requirements": ["leapmotor-api>=0.1.4"],
+  "version": "0.5.18"
 }

--- a/custom_components/leapmotor/remote_helpers.py
+++ b/custom_components/leapmotor/remote_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
@@ -75,6 +76,7 @@ async def async_execute_remote_action(
     coordinator: LeapmotorDataUpdateCoordinator,
     vin: str,
     spec: RemoteActionSpec,
+    kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Execute one remote action with shared cooldown, error and refresh handling."""
     cooldown = coordinator.remote_action_cooldown_remaining(vin)
@@ -89,8 +91,9 @@ async def async_execute_remote_action(
         )
 
     method = getattr(coordinator.client, spec.method_name)
+    callable_ = partial(method, vin, **kwargs) if kwargs else partial(method, vin)
     try:
-        result = await coordinator.hass.async_add_executor_job(method, vin)
+        result = await coordinator.hass.async_add_executor_job(callable_)
     except LeapmotorApiError as exc:
         coordinator.record_remote_action(
             vin,

--- a/custom_components/leapmotor/sensor.py
+++ b/custom_components/leapmotor/sensor.py
@@ -401,6 +401,84 @@ SENSOR_DESCRIPTIONS: tuple[LeapmotorSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data["diagnostics"].get("tire_pressure_rear_right_bar"),
     ),
+    LeapmotorSensorEntityDescription(
+        key="total_energy_kwh",
+        translation_key="total_energy_kwh",
+        native_unit_of_measurement=ENERGY_KWH,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=1,
+        icon="mdi:lightning-bolt",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["history"].get("total_energy_kwh"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="window_left_front_percent",
+        translation_key="window_left_front_percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:car-door",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("windows") or {}).get("left_front_percent"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="window_right_front_percent",
+        translation_key="window_right_front_percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:car-door",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("windows") or {}).get("right_front_percent"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="window_left_rear_percent",
+        translation_key="window_left_rear_percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:car-door",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("windows") or {}).get("left_rear_percent"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="window_right_rear_percent",
+        translation_key="window_right_rear_percent",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:car-door",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("windows") or {}).get("right_rear_percent"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="sunshade_position",
+        translation_key="sunshade_position",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:blinds-horizontal",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("windows") or {}).get("sun_shade"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="unread_message_count",
+        translation_key="unread_message_count",
+        icon="mdi:message-badge",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (data.get("messages") or {}).get("unread_count"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="last_message_title",
+        translation_key="last_message_title",
+        icon="mdi:message-text",
+        value_fn=lambda data: (data.get("messages") or {}).get("last_title"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="last_message_time",
+        translation_key="last_message_time",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (
+            datetime.fromtimestamp(ts / 1000, UTC)
+            if (ts := (data.get("messages") or {}).get("last_send_time")) is not None
+            else None
+        ),
+    ),
 )
 
 

--- a/custom_components/leapmotor/services.yaml
+++ b/custom_components/leapmotor/services.yaml
@@ -72,8 +72,18 @@ find_car:
         text:
 sunshade_open:
   name: Open sunshade
-  description: Open the sunshade.
+  description: Open the sunshade. Optionally set a partial position (0–10, 10 = fully open).
   fields:
+    value:
+      name: Position
+      description: Optional position 0–10. Omit for fully open.
+      example: 5
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          mode: box
     vin:
       name: VIN
       description: Target VIN. Required when multiple vehicles are configured.
@@ -86,8 +96,18 @@ sunshade_open:
         text:
 sunshade_close:
   name: Close sunshade
-  description: Close the sunshade.
+  description: Close the sunshade. Optionally set a partial position (0–10, 0 = fully closed).
   fields:
+    value:
+      name: Position
+      description: Optional position 0–10. Omit for fully closed.
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          mode: box
     vin:
       name: VIN
       description: Target VIN. Required when multiple vehicles are configured.
@@ -114,8 +134,18 @@ battery_preheat:
         text:
 windows_open:
   name: Open windows
-  description: Open the windows.
+  description: Open the windows. Optionally set a partial position (0–100, 100 = fully open).
   fields:
+    value:
+      name: Position
+      description: Optional position 0–100. Omit for fully open.
+      example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
     vin:
       name: VIN
       description: Target VIN. Required when multiple vehicles are configured.
@@ -128,8 +158,18 @@ windows_open:
         text:
 windows_close:
   name: Close windows
-  description: Close the windows.
+  description: Close the windows. Optionally set a partial position (0–100, 0 = fully closed).
   fields:
+    value:
+      name: Position
+      description: Optional position 0–100. Omit for fully closed.
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
     vin:
       name: VIN
       description: Target VIN. Required when multiple vehicles are configured.

--- a/custom_components/leapmotor/translations/de.json
+++ b/custom_components/leapmotor/translations/de.json
@@ -121,6 +121,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Reifendruck hinten rechts"
+      },
+      "total_energy_kwh": {
+        "name": "Gesamtenergie"
+      },
+      "window_left_front_percent": {
+        "name": "Fenster vorne links"
+      },
+      "window_right_front_percent": {
+        "name": "Fenster vorne rechts"
+      },
+      "window_left_rear_percent": {
+        "name": "Fenster hinten links"
+      },
+      "window_right_rear_percent": {
+        "name": "Fenster hinten rechts"
+      },
+      "sunshade_position": {
+        "name": "Sonnenschutzposition"
+      },
+      "unread_message_count": {
+        "name": "Ungelesene Nachrichten"
+      },
+      "last_message_title": {
+        "name": "Letzte Nachricht"
+      },
+      "last_message_time": {
+        "name": "Letzte Nachricht Zeit"
       }
     },
     "binary_sensor": {
@@ -132,6 +159,12 @@
       },
       "charging_planned_enabled": {
         "name": "Geplantes Laden"
+      },
+      "is_plugged": {
+        "name": "Angesteckt"
+      },
+      "is_regening": {
+        "name": "Rekuperiert"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -121,6 +121,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Tire pressure rear right"
+      },
+      "total_energy_kwh": {
+        "name": "Total energy"
+      },
+      "window_left_front_percent": {
+        "name": "Window front left"
+      },
+      "window_right_front_percent": {
+        "name": "Window front right"
+      },
+      "window_left_rear_percent": {
+        "name": "Window rear left"
+      },
+      "window_right_rear_percent": {
+        "name": "Window rear right"
+      },
+      "sunshade_position": {
+        "name": "Sunshade position"
+      },
+      "unread_message_count": {
+        "name": "Unread messages"
+      },
+      "last_message_title": {
+        "name": "Last message"
+      },
+      "last_message_time": {
+        "name": "Last message time"
       }
     },
     "binary_sensor": {
@@ -132,6 +159,12 @@
       },
       "charging_planned_enabled": {
         "name": "Scheduled charging"
+      },
+      "is_plugged": {
+        "name": "Plugged in"
+      },
+      "is_regening": {
+        "name": "Regenerating"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/es.json
+++ b/custom_components/leapmotor/translations/es.json
@@ -112,6 +112,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Presion neumatico trasero derecho"
+      },
+      "total_energy_kwh": {
+        "name": "Energía total"
+      },
+      "window_left_front_percent": {
+        "name": "Ventana delantera izquierda"
+      },
+      "window_right_front_percent": {
+        "name": "Ventana delantera derecha"
+      },
+      "window_left_rear_percent": {
+        "name": "Ventana trasera izquierda"
+      },
+      "window_right_rear_percent": {
+        "name": "Ventana trasera derecha"
+      },
+      "sunshade_position": {
+        "name": "Posición parasol"
+      },
+      "unread_message_count": {
+        "name": "Mensajes no leídos"
+      },
+      "last_message_title": {
+        "name": "Último mensaje"
+      },
+      "last_message_time": {
+        "name": "Hora del último mensaje"
       }
     },
     "binary_sensor": {
@@ -123,6 +150,12 @@
       },
       "charging_planned_enabled": {
         "name": "Carga programada"
+      },
+      "is_plugged": {
+        "name": "Enchufado"
+      },
+      "is_regening": {
+        "name": "Recuperando"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/fr.json
+++ b/custom_components/leapmotor/translations/fr.json
@@ -112,6 +112,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Pression pneu arriere droit"
+      },
+      "total_energy_kwh": {
+        "name": "Énergie totale"
+      },
+      "window_left_front_percent": {
+        "name": "Vitre avant gauche"
+      },
+      "window_right_front_percent": {
+        "name": "Vitre avant droite"
+      },
+      "window_left_rear_percent": {
+        "name": "Vitre arrière gauche"
+      },
+      "window_right_rear_percent": {
+        "name": "Vitre arrière droite"
+      },
+      "sunshade_position": {
+        "name": "Position du pare-soleil"
+      },
+      "unread_message_count": {
+        "name": "Messages non lus"
+      },
+      "last_message_title": {
+        "name": "Dernier message"
+      },
+      "last_message_time": {
+        "name": "Heure du dernier message"
       }
     },
     "binary_sensor": {
@@ -123,6 +150,12 @@
       },
       "charging_planned_enabled": {
         "name": "Charge programmee"
+      },
+      "is_plugged": {
+        "name": "Branché"
+      },
+      "is_regening": {
+        "name": "En récupération"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/it.json
+++ b/custom_components/leapmotor/translations/it.json
@@ -112,6 +112,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Pressione pneumatico posteriore destro"
+      },
+      "total_energy_kwh": {
+        "name": "Energia totale"
+      },
+      "window_left_front_percent": {
+        "name": "Finestrino anteriore sinistro"
+      },
+      "window_right_front_percent": {
+        "name": "Finestrino anteriore destro"
+      },
+      "window_left_rear_percent": {
+        "name": "Finestrino posteriore sinistro"
+      },
+      "window_right_rear_percent": {
+        "name": "Finestrino posteriore destro"
+      },
+      "sunshade_position": {
+        "name": "Posizione tendina"
+      },
+      "unread_message_count": {
+        "name": "Messaggi non letti"
+      },
+      "last_message_title": {
+        "name": "Ultimo messaggio"
+      },
+      "last_message_time": {
+        "name": "Ora ultimo messaggio"
       }
     },
     "binary_sensor": {
@@ -123,6 +150,12 @@
       },
       "charging_planned_enabled": {
         "name": "Ricarica programmata"
+      },
+      "is_plugged": {
+        "name": "Collegato"
+      },
+      "is_regening": {
+        "name": "In recupero"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -112,6 +112,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Bandenspanning rechtsachter"
+      },
+      "total_energy_kwh": {
+        "name": "Totale energie"
+      },
+      "window_left_front_percent": {
+        "name": "Raam voor links"
+      },
+      "window_right_front_percent": {
+        "name": "Raam voor rechts"
+      },
+      "window_left_rear_percent": {
+        "name": "Raam achter links"
+      },
+      "window_right_rear_percent": {
+        "name": "Raam achter rechts"
+      },
+      "sunshade_position": {
+        "name": "Zonnescherm positie"
+      },
+      "unread_message_count": {
+        "name": "Ongelezen berichten"
+      },
+      "last_message_title": {
+        "name": "Laatste bericht"
+      },
+      "last_message_time": {
+        "name": "Tijd laatste bericht"
       }
     },
     "binary_sensor": {
@@ -123,6 +150,12 @@
       },
       "charging_planned_enabled": {
         "name": "Gepland laden"
+      },
+      "is_plugged": {
+        "name": "Ingeplugd"
+      },
+      "is_regening": {
+        "name": "Recupereert"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/pl.json
+++ b/custom_components/leapmotor/translations/pl.json
@@ -112,6 +112,33 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Cisnienie opony tylnej prawej"
+      },
+      "total_energy_kwh": {
+        "name": "Energia całkowita"
+      },
+      "window_left_front_percent": {
+        "name": "Okno przednie lewe"
+      },
+      "window_right_front_percent": {
+        "name": "Okno przednie prawe"
+      },
+      "window_left_rear_percent": {
+        "name": "Okno tylne lewe"
+      },
+      "window_right_rear_percent": {
+        "name": "Okno tylne prawe"
+      },
+      "sunshade_position": {
+        "name": "Pozycja rolety"
+      },
+      "unread_message_count": {
+        "name": "Nieprzeczytane wiadomości"
+      },
+      "last_message_title": {
+        "name": "Ostatnia wiadomość"
+      },
+      "last_message_time": {
+        "name": "Czas ostatniej wiadomości"
       }
     },
     "binary_sensor": {
@@ -123,6 +150,12 @@
       },
       "charging_planned_enabled": {
         "name": "Planowane ladowanie"
+      },
+      "is_plugged": {
+        "name": "Podłączony"
+      },
+      "is_regening": {
+        "name": "Rekuperacja"
       }
     },
     "image": {


### PR DESCRIPTION
`api.py` was getting large enough that it made sense to extract the API layer into a separate package. markoceri did exactly that with [leapmotor-api](https://github.com/markoceri/leapmotor-api), which was extracted from this repo. This PR completes the loop by making the integration use it.

The bundled `api.py` is replaced with a thin shim that wraps `LeapmotorApiClient` from the library. The shim keeps the same constructor interface so nothing else in the integration changes. It overrides `_fetch_authenticated_data` to add consumption history and notification calls that aren't in the base library yet (a separate PR to leapmotor-api covers those).

`manifest.json` drops the two raw requirements and lists `leapmotor-api>=0.1.4` instead.

## Signal fixes in the shim

Two signal mappings were wrong:

- `is_locked` was reading signal `47`. Signal `47` is the charge-cable plug indicator, not lock state. Lock state is signal `1298` (1 = locked, 0 = unlocked), matching what you fixed in 0.5.20.
- `is_plugged_in` now reads signal `47` directly (1 = plugged) with a `1149` fallback, instead of deriving it from charge status `1939`.

## New sensors

All have translation keys with entries in all 7 existing language files.

Binary sensors: `is_plugged_in`, `is_regening` (charging power flowing while disconnected from external charger).

Sensors: `total_energy_kwh`, four window position sensors (`window_left_front_percent` etc.), `sunshade_position`, `unread_message_count`, `last_message_title`, `last_message_time`.

## Partial window/sunshade positioning

`windows_open`, `windows_close`, `sunshade_open`, and `sunshade_close` services accept an optional `value` parameter. Windows take 0-100, sunshade takes 0-10. Omitting it sends the default fully-open or fully-closed payload, so button entities work as before without changes.

## Other

`vehicle_nickname` replaces `nickname` in `entity_helpers.py` and `diagnostics.py` to match the field name in leapmotor-api's `normalize_vehicle`. A fallback to `nickname` is kept for compatibility.

---

**Note: untested.** I don't have app certificates or a car, so none of this has run against a live API. The logic is taken directly from the existing implementation, but it needs someone with actual hardware to verify.