### PR TITLE
Add regenerative braking binary sensor

### DIFF
--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1461,6 +1461,7 @@ def normalize_vehicle(
         "charging": {
             "is_charging": _is_charging(signal),
             "is_plugged_in": _is_plugged_in(signal),
+            "is_regening": _is_regening(signal),
             "connection_state": _charging_connection_state(signal),
             "charge_limit_percent": charge_plan.get("percent"),
             "remaining_charge_minutes": _safe_int(signal.get("1200")),
@@ -1844,6 +1845,21 @@ def _is_plugged_in(signal: dict[str, Any]) -> bool | None:
     if connection_status is not None:
         return connection_status in (1, 2)
     return None
+
+
+def _is_regening(signal: dict[str, Any]) -> bool | None:
+    """Return whether the vehicle is regeneratively braking.
+
+    True when charging power is flowing into the battery while no external
+    charge cable is connected. Derived from the same signals as is_plugged_in
+    and charging_power_kw; needs field validation on a live vehicle.
+    """
+    plugged_in = _is_plugged_in(signal)
+    if plugged_in is None:
+        return None
+    if plugged_in:
+        return False
+    return _is_charging(signal)
 
 
 def _charging_connection_state(signal: dict[str, Any]) -> str | None:

--- a/custom_components/leapmotor/binary_sensor.py
+++ b/custom_components/leapmotor/binary_sensor.py
@@ -244,6 +244,13 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[LeapmotorBinarySensorEntityDescription, ...] =
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data["diagnostics"].get("fully_charged"),
     ),
+    LeapmotorBinarySensorEntityDescription(
+        key="is_regening",
+        translation_key="is_regening",
+        icon="mdi:car-electric",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["charging"].get("is_regening"),
+    ),
 )
 
 

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -132,6 +132,9 @@
       },
       "charging_planned_enabled": {
         "name": "Scheduled charging"
+      },
+      "is_regening": {
+        "name": "Regenerative braking"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -123,6 +123,9 @@
       },
       "charging_planned_enabled": {
         "name": "Gepland laden"
+      },
+      "is_regening": {
+        "name": "Regeneratief remmen"
       }
     },
     "image": {


### PR DESCRIPTION
Adds an `is_regening` binary sensor that turns on when the vehicle is charging but not connected to an external charger — i.e. regen braking is actively pushing current back into the pack.

## How it works

A new `_is_regening` helper is added to `api.py`, sitting alongside `_is_plugged_in` and `_is_charging`. The logic is straightforward:

- if `is_plugged_in` is unknown → return `None`
- if plugged in → `False` (that's external charging, not regen)
- otherwise → delegate to `is_charging` (power flowing into the battery while driving)

The sensor reads `data["charging"]["is_regening"]` in the same way every other binary sensor reads its value.

Translation keys added for EN and NL. Other languages are welcome.

## Notes

Haven't been able to test this against a live vehicle — no car available on our end. The derivation logic is taken from the [leapmotor-api](https://github.com/markoceri/leapmotor-api) library, which went through its own testing cycle before release, so the signal interpretation should be solid. Would be great if someone with a car could confirm the sensor flips correctly when coasting downhill.