### PR TITLE
Add notification sensors (unread count, last message)

### DIFF
--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -384,6 +384,7 @@ class LeapmotorApiClient:
             "vehicles": {},
             "account_p12_password_source": self.account_p12_password_source,
         }
+        notifications = self._fetch_account_notifications()
         for vehicle in vehicles:
             status = self.get_vehicle_status(vehicle)
             mileage = self._fetch_optional_read(
@@ -406,7 +407,7 @@ class LeapmotorApiClient:
                 self.get_car_picture,
                 vehicle,
             )
-            result["vehicles"][vehicle.vin] = normalize_vehicle(
+            vehicle_data = normalize_vehicle(
                 vehicle,
                 status,
                 self.user_id,
@@ -415,6 +416,8 @@ class LeapmotorApiClient:
                 consumption_breakdown_json=consumption_breakdown,
                 picture_json=picture,
             )
+            vehicle_data["notifications"] = notifications
+            result["vehicles"][vehicle.vin] = vehicle_data
         return result
 
     def _fetch_optional_read(
@@ -429,6 +432,45 @@ class LeapmotorApiClient:
         except LeapmotorApiError as exc:
             _LOGGER.debug("Leapmotor optional read failed for %s: %s", label, exc)
             return None
+
+    def _fetch_account_notifications(self) -> dict[str, Any]:
+        """Fetch account-level notification data; returns empty values on failure."""
+        empty: dict[str, Any] = {
+            "unread_count": None,
+            "last_message_title": None,
+            "last_message_time": None,
+        }
+        try:
+            headers = self._build_signed_headers()
+            headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
+            resp = self._post_with_curl(
+                path="/carownerservice/oversea/message/v1/unread/count",
+                headers=headers,
+                data="",
+                cert=self.account_cert,
+            )
+            body = self._parse_api_body(resp["status_code"], resp["body"], "unread count")
+            unread = int((body.get("data") or {}).get("unread", 0))
+
+            list_headers = self._build_message_list_headers()
+            list_headers.update(self._auth_headers(content_type="application/x-www-form-urlencoded"))
+            resp2 = self._post_with_curl(
+                path="/carownerservice/oversea/message/v1/list",
+                headers=list_headers,
+                data="pageNo=1&pageSize=1",
+                cert=self.account_cert,
+            )
+            body2 = self._parse_api_body(resp2["status_code"], resp2["body"], "message list")
+            messages = (body2.get("data") or {}).get("list") or []
+            latest = messages[0] if messages else {}
+            return {
+                "unread_count": unread,
+                "last_message_title": latest.get("title"),
+                "last_message_time": latest.get("sendTime"),
+            }
+        except LeapmotorApiError as exc:
+            _LOGGER.debug("Leapmotor notification fetch failed: %s", exc)
+            return empty
 
     def login(self) -> None:
         """Login with the static app cert and load the account cert from the response."""
@@ -963,6 +1005,28 @@ class LeapmotorApiClient:
             "timestamp": timestamp,
             "sign": hmac.new(self.sign_key, sign_input.encode("utf-8"), hashlib.sha256).hexdigest(),
         }
+
+    def _build_message_list_headers(self, *, page_no: int = 1, page_size: int = 1) -> dict[str, str]:
+        """Build signed headers for the message list endpoint.
+
+        The pageNo and pageSize body params are included in the signature,
+        sorted alphabetically with the standard fields (between nonce and source).
+        """
+        nonce = str(random.randint(100000, 9999999))
+        timestamp = str(int(time.time() * 1000))
+        sign_input = "".join([
+            DEFAULT_LANGUAGE,
+            DEFAULT_CHANNEL,
+            self.device_id,
+            DEFAULT_DEVICE_TYPE,
+            nonce,
+            str(page_no),
+            str(page_size),
+            DEFAULT_SOURCE,
+            timestamp,
+            DEFAULT_APP_VERSION,
+        ])
+        return self._signed_header_dict(nonce=nonce, timestamp=timestamp, sign_input=sign_input)
 
     def _build_consumption_weekly_rank_headers(self, *, carvin: str) -> dict[str, str]:
         """Build the signature variant used by getLastNweeks100kmECAndRank."""

--- a/custom_components/leapmotor/sensor.py
+++ b/custom_components/leapmotor/sensor.py
@@ -510,6 +510,27 @@ SENSOR_DESCRIPTIONS: tuple[LeapmotorSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data["diagnostics"].get("tire_pressure_rear_right_bar"),
     ),
+    LeapmotorSensorEntityDescription(
+        key="unread_message_count",
+        translation_key="unread_message_count",
+        icon="mdi:message-badge",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("notifications") or {}).get("unread_count"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="last_message_title",
+        translation_key="last_message_title",
+        icon="mdi:message-text",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("notifications") or {}).get("last_message_title"),
+    ),
+    LeapmotorSensorEntityDescription(
+        key="last_message_time",
+        translation_key="last_message_time",
+        icon="mdi:message-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: (data.get("notifications") or {}).get("last_message_time"),
+    ),
 )
 
 

--- a/custom_components/leapmotor/translations/de.json
+++ b/custom_components/leapmotor/translations/de.json
@@ -121,6 +121,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Reifendruck hinten rechts"
+      },
+      "unread_message_count": {
+        "name": "Ungelesene Nachrichten"
+      },
+      "last_message_title": {
+        "name": "Letzte Nachricht"
+      },
+      "last_message_time": {
+        "name": "Zeitpunkt letzte Nachricht"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -121,6 +121,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Tire pressure rear right"
+      },
+      "unread_message_count": {
+        "name": "Unread messages"
+      },
+      "last_message_title": {
+        "name": "Last message"
+      },
+      "last_message_time": {
+        "name": "Last message time"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/es.json
+++ b/custom_components/leapmotor/translations/es.json
@@ -112,6 +112,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Presion neumatico trasero derecho"
+      },
+      "unread_message_count": {
+        "name": "Mensajes no leídos"
+      },
+      "last_message_title": {
+        "name": "Último mensaje"
+      },
+      "last_message_time": {
+        "name": "Hora último mensaje"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/fr.json
+++ b/custom_components/leapmotor/translations/fr.json
@@ -112,6 +112,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Pression pneu arriere droit"
+      },
+      "unread_message_count": {
+        "name": "Messages non lus"
+      },
+      "last_message_title": {
+        "name": "Dernier message"
+      },
+      "last_message_time": {
+        "name": "Heure dernier message"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/it.json
+++ b/custom_components/leapmotor/translations/it.json
@@ -112,6 +112,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Pressione pneumatico posteriore destro"
+      },
+      "unread_message_count": {
+        "name": "Messaggi non letti"
+      },
+      "last_message_title": {
+        "name": "Ultimo messaggio"
+      },
+      "last_message_time": {
+        "name": "Ora ultimo messaggio"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -112,6 +112,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Bandenspanning rechtsachter"
+      },
+      "unread_message_count": {
+        "name": "Ongelezen berichten"
+      },
+      "last_message_title": {
+        "name": "Laatste bericht"
+      },
+      "last_message_time": {
+        "name": "Tijd laatste bericht"
       }
     },
     "binary_sensor": {

--- a/custom_components/leapmotor/translations/pl.json
+++ b/custom_components/leapmotor/translations/pl.json
@@ -112,6 +112,15 @@
       },
       "tire_pressure_rear_right_bar": {
         "name": "Cisnienie opony tylnej prawej"
+      },
+      "unread_message_count": {
+        "name": "Nieprzeczytane wiadomości"
+      },
+      "last_message_title": {
+        "name": "Ostatnia wiadomość"
+      },
+      "last_message_time": {
+        "name": "Czas ostatniej wiadomości"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
Hooks the Leapmotor message API into the integration to surface three new sensors: unread message count, the title of the most recent message, and when it was sent.

## How it works

Two endpoints are called once per refresh cycle, outside the vehicle loop, so the overhead is minimal:

- `POST /message/v1/unread/count` — returns the unread count (same auth pattern as every other read endpoint)
- `POST /message/v1/list` with `pageNo=1&pageSize=1` — returns the most recent message

The second endpoint needs `pageNo` and `pageSize` included in the HMAC signature. Added `_build_message_list_headers()` for that, following the same pattern as `_build_mileage_energy_detail_headers` and `_build_consumption_weekly_rank_headers`.

Results are injected into each vehicle's data dict under `"notifications"` so the sensors can use the standard `value_fn` pattern.

Failures on either endpoint are caught and silenced — the rest of the update carries on normally.

Translations added for all 7 languages.

## Notes

Haven't been able to test against a live vehicle. The endpoint paths, request shape, and response structure come from the [leapmotor-api](https://github.com/markoceri/leapmotor-api) library which went through its own testing before release. Would appreciate a confirmation that the sensors show up and populate correctly.