### PR TITLE
fix: lower charging current threshold from 3.0A to 1.0A for B10 compatibility

### DIFF
--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1960,8 +1960,12 @@ def _is_charging(signal: dict[str, Any]) -> bool:
         # Confirmed charging sessions show a clearly non-zero current
         # (typically negative while energy flows into the pack). After
         # charge completion the backend can keep 1149=2 while current is 0.
-        if abs(charging_current_a) < 3.0:
+        if abs(charging_current_a) < 1.0:
             return False
+        # 1.0–3.0 A: grey zone — C10 idles at ~1.5A when plugged but not charging.
+        # Require remaining_charge_minutes as confirmation to avoid false positives.
+        if abs(charging_current_a) < 3.0:
+            return remaining_charge_minutes is not None and remaining_charge_minutes > 0
         return remaining_charge_minutes is not None or (
             charging_power_kw is not None and charging_power_kw >= 1.0
         )
@@ -2006,7 +2010,7 @@ def _charging_connection_state(signal: dict[str, Any]) -> str | None:
     if _charge_is_finished(signal):
         return "finished"
     charging_current_a = _safe_float(signal.get("1178"))
-    if charging_current_a is not None and abs(charging_current_a) < 3.0:
+    if charging_current_a is not None and abs(charging_current_a) < 1.0:
         return "plugged_in" if _is_plugged_in(signal) else "unplugged"
     connection_status = _safe_int(signal.get("1149"))
     if connection_status == 0:
@@ -2053,7 +2057,8 @@ def _charging_power_kw(signal: dict[str, Any]) -> float | None:
     voltage = _safe_float(signal.get("1177"))
     if current is None or voltage is None:
         return None
-    # The C10 plugged-idle snapshot shows about 1.5A without active charging.
-    if abs(current) < 3.0:
+    # The C10 plugged-idle snapshot shows about 1.5A without active charging,
+    # but the B10 can charge at ~2.5A — threshold lowered to 1.0A.
+    if abs(current) < 1.0:
         return None
     return round(abs(current * voltage) / 1000.0, 3)


### PR DESCRIPTION
The B10 charges at ~2.5A AC, which was below the previous 3.0A threshold
in `_is_charging()`. This caused the function to return `False` during
active charging, breaking two sensors:
- `sensor.leapmotor_charging_power` → unknown
- `sensor.leapmotor_remaining_charge_time` → unavailable

**Fix:**
- Threshold lowered to 1.0A (clearly no charging below this)
- Grey zone 1.0–3.0A: requires `remaining_charge_minutes > 0` as
  confirmation to avoid false positives on C10 units that idle at ~1.5A
  when plugged in but not actively charging
- Same threshold applied consistently in `_charging_connection_state`
  and `_charging_power_kw`

Tested on B10 2025 charging at ~2.5A / ~1.4 kW.