### PR TITLE
fix: add ENUM device class and translated states for vehicle_state and charging_connection_state

### DIFF
--- a/custom_components/leapmotor/sensor.py
+++ b/custom_components/leapmotor/sensor.py
@@ -215,6 +215,8 @@ SENSOR_DESCRIPTIONS: tuple[LeapmotorSensorEntityDescription, ...] = (
     LeapmotorSensorEntityDescription(
         key="charging_connection_state",
         translation_key="charging_connection_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=["unplugged", "plugged_in", "charging", "finished"],
         icon="mdi:ev-plug-type2",
         value_fn=lambda data: data["charging"].get("connection_state"),
     ),
@@ -284,6 +286,8 @@ SENSOR_DESCRIPTIONS: tuple[LeapmotorSensorEntityDescription, ...] = (
     LeapmotorSensorEntityDescription(
         key="vehicle_state",
         translation_key="vehicle_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=["parked", "driving"],
         icon="mdi:car-info",
         value_fn=lambda data: data["status"].get("vehicle_state"),
     ),

--- a/custom_components/leapmotor/translations/de.json
+++ b/custom_components/leapmotor/translations/de.json
@@ -104,7 +104,11 @@
         "name": "Ladeplanung aktualisiert"
       },
       "vehicle_state": {
-        "name": "Fahrzeugstatus"
+        "name": "Fahrzeugstatus",
+        "state": {
+          "parked": "Geparkt",
+          "driving": "Fahrt"
+        }
       },
       "last_successful_refresh": {
         "name": "Zuletzt aktualisiert"
@@ -155,7 +159,13 @@
         "name": "Ladespannung"
       },
       "charging_connection_state": {
-        "name": "Ladeverbindung"
+        "name": "Ladeverbindung",
+        "state": {
+          "unplugged": "Nicht verbunden",
+          "plugged_in": "Verbunden",
+          "charging": "Lädt",
+          "finished": "Geladen"
+        }
       },
       "battery_min_temp_c": {
         "name": "Batterie-Minimaltemperatur"

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -104,7 +104,11 @@
         "name": "Charging schedule updated"
       },
       "vehicle_state": {
-        "name": "Vehicle state"
+        "name": "Vehicle state",
+        "state": {
+          "parked": "Parked",
+          "driving": "Driving"
+        }
       },
       "last_successful_refresh": {
         "name": "Last refresh"
@@ -155,7 +159,13 @@
         "name": "Charging voltage"
       },
       "charging_connection_state": {
-        "name": "Charging connection"
+        "name": "Charging connection",
+        "state": {
+          "unplugged": "Unplugged",
+          "plugged_in": "Plugged in",
+          "charging": "Charging",
+          "finished": "Charge complete"
+        }
       },
       "battery_min_temp_c": {
         "name": "Battery minimum temperature"

--- a/custom_components/leapmotor/translations/es.json
+++ b/custom_components/leapmotor/translations/es.json
@@ -104,7 +104,11 @@
         "name": "Plan de carga actualizado"
       },
       "vehicle_state": {
-        "name": "Estado del vehículo"
+        "name": "Estado del vehículo",
+        "state": {
+          "parked": "Aparcado",
+          "driving": "En marcha"
+        }
       },
       "total_mileage_km": {
         "name": "Kilometraje total"
@@ -164,7 +168,13 @@
         "name": "Tensión de carga"
       },
       "charging_connection_state": {
-        "name": "Conexión de carga"
+        "name": "Conexión de carga",
+        "state": {
+          "unplugged": "Desconectado",
+          "plugged_in": "Conectado",
+          "charging": "Cargando",
+          "finished": "Carga completada"
+        }
       },
       "battery_min_temp_c": {
         "name": "Temperatura mínima de batería"

--- a/custom_components/leapmotor/translations/fr.json
+++ b/custom_components/leapmotor/translations/fr.json
@@ -104,7 +104,11 @@
         "name": "Programme de charge mis à jour"
       },
       "vehicle_state": {
-        "name": "État du véhicule"
+        "name": "État du véhicule",
+        "state": {
+          "parked": "Garé",
+          "driving": "En conduite"
+        }
       },
       "total_mileage_km": {
         "name": "Kilométrage total"
@@ -164,7 +168,13 @@
         "name": "Tension de charge"
       },
       "charging_connection_state": {
-        "name": "Connexion de charge"
+        "name": "Connexion de charge",
+        "state": {
+          "unplugged": "Débranché",
+          "plugged_in": "Branché",
+          "charging": "En charge",
+          "finished": "Charge terminée"
+        }
       },
       "battery_min_temp_c": {
         "name": "Température minimale batterie"

--- a/custom_components/leapmotor/translations/it.json
+++ b/custom_components/leapmotor/translations/it.json
@@ -104,7 +104,11 @@
         "name": "Piano carica aggiornato"
       },
       "vehicle_state": {
-        "name": "Stato veicolo"
+        "name": "Stato veicolo",
+        "state": {
+          "parked": "Parcheggiato",
+          "driving": "In guida"
+        }
       },
       "total_mileage_km": {
         "name": "Chilometraggio totale"
@@ -164,7 +168,13 @@
         "name": "Tensione di carica"
       },
       "charging_connection_state": {
-        "name": "Connessione di carica"
+        "name": "Connessione di carica",
+        "state": {
+          "unplugged": "Scollegato",
+          "plugged_in": "Collegato",
+          "charging": "In carica",
+          "finished": "Carica completata"
+        }
       },
       "battery_min_temp_c": {
         "name": "Temperatura minima batteria"

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -104,7 +104,11 @@
         "name": "Laadplanning bijgewerkt"
       },
       "vehicle_state": {
-        "name": "Voertuigstatus"
+        "name": "Voertuigstatus",
+        "state": {
+          "parked": "Geparkeerd",
+          "driving": "Rijden"
+        }
       },
       "total_mileage_km": {
         "name": "Totale kilometerstand"
@@ -164,7 +168,13 @@
         "name": "Laadspanning"
       },
       "charging_connection_state": {
-        "name": "Laadverbinding"
+        "name": "Laadverbinding",
+        "state": {
+          "unplugged": "Niet aangesloten",
+          "plugged_in": "Aangesloten",
+          "charging": "Aan het laden",
+          "finished": "Opladen voltooid"
+        }
       },
       "battery_min_temp_c": {
         "name": "Minimale accutemperatuur"

--- a/custom_components/leapmotor/translations/pl.json
+++ b/custom_components/leapmotor/translations/pl.json
@@ -104,7 +104,11 @@
         "name": "Plan ładowania zaktualizowany"
       },
       "vehicle_state": {
-        "name": "Stan pojazdu"
+        "name": "Stan pojazdu",
+        "state": {
+          "parked": "Zaparkowany",
+          "driving": "Jazda"
+        }
       },
       "total_mileage_km": {
         "name": "Całkowity przebieg"
@@ -164,7 +168,13 @@
         "name": "Napięcie ładowania"
       },
       "charging_connection_state": {
-        "name": "Połączenie ładowania"
+        "name": "Połączenie ładowania",
+        "state": {
+          "unplugged": "Odłączony",
+          "plugged_in": "Podłączony",
+          "charging": "Ładowanie",
+          "finished": "Ładowanie zakończone"
+        }
       },
       "battery_min_temp_c": {
         "name": "Minimalna temperatura baterii"


### PR DESCRIPTION
Both sensors were showing raw string values (e.g. "parked", "plugged_in")
without Home Assistant translation support.

**Changes:**
- Added `device_class=SensorDeviceClass.ENUM` and `options` to both sensor descriptions
- Added `state` translation entries in all 7 supported languages (de, en, es, fr, it, nl, pl)

`vehicle_state` states: `parked`, `driving`
`charging_connection_state` states: `unplugged`, `plugged_in`, `charging`, `finished`