### PR TITLE
fix: add is_driving detection from ON3 + gear signals

### DIFF
--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1457,6 +1457,7 @@ def normalize_vehicle(
             "odometer_km": signal.get("1318"),
             "speed_kmh": _safe_float(signal.get("1319")),
             "gear": _gear_state(signal),
+            "is_driving": _is_driving(signal),
             "battery_percent_precise": _safe_float(signal.get("100003")),
             "cltc_range_km": _safe_int(signal.get("3257")),
             "wltp_max_range_km": _safe_int(signal.get("3257")),
@@ -2032,6 +2033,15 @@ def _is_regening(signal: dict[str, Any]) -> bool | None:
     if plugged_in:
         return False
     return _is_charging(signal)
+
+
+def _is_driving(signal: dict[str, Any]) -> bool | None:
+    """Return True when ignition ON3 is active and gear is DRIVE or REVERSE."""
+    on3 = _one_is_on(signal.get("1258"))
+    gear = _safe_int(signal.get("1010"))
+    if on3 is None or gear is None:
+        return None
+    return on3 and gear in (1, 3)
 
 
 def _charging_connection_state(signal: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary

- Adds `_is_driving(signal)` helper: `True` when ignition ON3 (signal 1258) is active and gear (signal 1010) is DRIVE (1) or REVERSE (3)
- Exposes `is_driving` in the `normalize_vehicle` status dict for downstream sensors

## Merge order

**1 of 5** — merge this first. #31 adds the binary sensor that reads this field.

## Test plan

- [ ] `is_driving` available in coordinator data while driving
- [ ] `False`/`None` when parked
- [ ] No regression on existing charging/plugged sensors