### PR TITLE
feat: is_driving and AC slow-charge binary sensors

### DIFF
--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1571,7 +1571,9 @@ def normalize_vehicle(
             "climate_on": _one_is_on(signal.get("1938")),
             "climate_mode": _climate_mode(signal),
             "outdoor_temp_c": _safe_float(status_data.get("outdoorTemp")),
-            "climate_fan_volume": _safe_int(status_data.get("acAirVolume")),
+            "climate_fan_volume": _safe_int(status_data.get("acAirVolume"))
+            if status_data.get("acAirVolume") is not None
+            else _safe_int(signal.get("1941")),
             "climate_fan_volume_setting": _safe_int(status_data.get("acAirVolumeSetting")),
             "climate_air_direction": _safe_int(status_data.get("acWindDirection")),
             "climate_temp_mode": _safe_bool(status_data.get("acTempMode")),
@@ -1599,6 +1601,7 @@ def normalize_vehicle(
             "sentinel_mode": _one_is_on(signal.get("3636")),
             "parking_photo": _one_is_on(signal.get("3638")),
             "fully_charged": _one_is_on(signal.get("3736")),
+            "charge_completed": _safe_bool(status_data.get("chargeCompleted")),
             "speed_limit_enabled": _one_is_on(signal.get("12054")),
             "speed_limit_kmh": _safe_int(signal.get("6048")),
             "speed_limit_unit": signal.get("6047"),

--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -1457,6 +1457,7 @@ def normalize_vehicle(
             "odometer_km": signal.get("1318"),
             "speed_kmh": _safe_float(signal.get("1319")),
             "gear": _gear_state(signal),
+            "is_driving": _is_driving(signal),
             "battery_percent_precise": _safe_float(signal.get("100003")),
             "cltc_range_km": _safe_int(signal.get("3257")),
             "wltp_max_range_km": _safe_int(signal.get("3257")),
@@ -1496,6 +1497,7 @@ def normalize_vehicle(
             "charging_current_a": _safe_float(signal.get("1178")),
             "charging_voltage_v": _safe_float(signal.get("1177")),
             "dc_cable_connected": _not_zero(signal.get("1197")),
+            "ac_input_slow_charge": _safe_int(signal.get("47")) == 1,
             "charging_planned_enabled": charge_plan.get("isEnable"),
             "charging_planned_start": charge_plan.get("beginTime"),
             "charging_planned_end": charge_plan.get("endTime"),
@@ -2032,6 +2034,15 @@ def _is_regening(signal: dict[str, Any]) -> bool | None:
     if plugged_in:
         return False
     return _is_charging(signal)
+
+
+def _is_driving(signal: dict[str, Any]) -> bool | None:
+    """Return True when ignition ON3 is active and gear is DRIVE or REVERSE."""
+    on3 = _one_is_on(signal.get("1258"))
+    gear = _safe_int(signal.get("1010"))
+    if on3 is None or gear is None:
+        return None
+    return on3 and gear in (1, 3)
 
 
 def _charging_connection_state(signal: dict[str, Any]) -> str | None:

--- a/custom_components/leapmotor/binary_sensor.py
+++ b/custom_components/leapmotor/binary_sensor.py
@@ -26,6 +26,7 @@ from .entity_migration import english_entity_slug
 OPTIONAL_BINARY_SENSOR_PATHS = {
     "is_driving": "status.is_driving",
     "ac_input_slow_charge": "charging.ac_input_slow_charge",
+    "charge_completed": "diagnostics.charge_completed",
     "charging_planned_enabled": "charging.charging_planned_enabled",
     "charging_planned_weekly": "charging.charging_planned_cycles",
     "remote_session_active": "diagnostics.remote_session_active",
@@ -330,6 +331,14 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[LeapmotorBinarySensorEntityDescription, ...] =
         icon="mdi:car-door",
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data["diagnostics"].get("door_control_allowed"),
+    ),
+    LeapmotorBinarySensorEntityDescription(
+        key="charge_completed",
+        translation_key="charge_completed",
+        icon="mdi:battery-check-outline",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["diagnostics"].get("charge_completed"),
     ),
 )
 

--- a/custom_components/leapmotor/binary_sensor.py
+++ b/custom_components/leapmotor/binary_sensor.py
@@ -24,6 +24,8 @@ from .entity_helpers import build_vehicle_display_name, load_localized_entity_na
 from .entity_migration import english_entity_slug
 
 OPTIONAL_BINARY_SENSOR_PATHS = {
+    "is_driving": "status.is_driving",
+    "ac_input_slow_charge": "charging.ac_input_slow_charge",
     "charging_planned_enabled": "charging.charging_planned_enabled",
     "charging_planned_weekly": "charging.charging_planned_cycles",
     "remote_session_active": "diagnostics.remote_session_active",
@@ -59,6 +61,21 @@ class LeapmotorBinarySensorEntityDescription(BinarySensorEntityDescription):
 
 
 BINARY_SENSOR_DESCRIPTIONS: tuple[LeapmotorBinarySensorEntityDescription, ...] = (
+    LeapmotorBinarySensorEntityDescription(
+        key="is_driving",
+        translation_key="is_driving",
+        icon="mdi:car-speed-limiter",
+        device_class=BinarySensorDeviceClass.MOTION,
+        value_fn=lambda data: data["status"].get("is_driving"),
+    ),
+    LeapmotorBinarySensorEntityDescription(
+        key="ac_input_slow_charge",
+        translation_key="ac_input_slow_charge",
+        icon="mdi:ev-plug-type1",
+        device_class=BinarySensorDeviceClass.PLUG,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data["charging"].get("ac_input_slow_charge"),
+    ),
     LeapmotorBinarySensorEntityDescription(
         key="is_charging",
         translation_key="is_charging",

--- a/custom_components/leapmotor/translations/de.json
+++ b/custom_components/leapmotor/translations/de.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Tuersteuerung erlaubt"
+      },
+      "is_driving": {
+        "name": "Faehrt"
+      },
+      "ac_input_slow_charge": {
+        "name": "AC-Ladekabel eingesteckt"
+      },
+      "charge_completed": {
+        "name": "Laden abgeschlossen"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -420,6 +420,9 @@
       },
       "ac_input_slow_charge": {
         "name": "AC slow charge plugged in"
+      },
+      "charge_completed": {
+        "name": "Charge completed"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -414,6 +414,12 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "Is driving"
+      },
+      "ac_input_slow_charge": {
+        "name": "AC slow charge plugged in"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/es.json
+++ b/custom_components/leapmotor/translations/es.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "Conduciendo"
+      },
+      "ac_input_slow_charge": {
+        "name": "Cable de carga AC conectado"
+      },
+      "charge_completed": {
+        "name": "Carga completada"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/fr.json
+++ b/custom_components/leapmotor/translations/fr.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "En conduite"
+      },
+      "ac_input_slow_charge": {
+        "name": "Cable de charge AC connecte"
+      },
+      "charge_completed": {
+        "name": "Charge terminee"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/it.json
+++ b/custom_components/leapmotor/translations/it.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "In guida"
+      },
+      "ac_input_slow_charge": {
+        "name": "Cavo di ricarica AC inserito"
+      },
+      "charge_completed": {
+        "name": "Ricarica completata"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "Rijden"
+      },
+      "ac_input_slow_charge": {
+        "name": "AC laadkabel aangesloten"
+      },
+      "charge_completed": {
+        "name": "Laden voltooid"
       }
     },
     "image": {

--- a/custom_components/leapmotor/translations/pl.json
+++ b/custom_components/leapmotor/translations/pl.json
@@ -414,6 +414,15 @@
       },
       "door_control_allowed": {
         "name": "Door control allowed"
+      },
+      "is_driving": {
+        "name": "W ruchu"
+      },
+      "ac_input_slow_charge": {
+        "name": "Kabel AC podlaczony"
+      },
+      "charge_completed": {
+        "name": "Ladowanie zakonczone"
       }
     },
     "image": {


### PR DESCRIPTION
## Summary

New optional binary sensor entities (only appear when vehicle reports relevant signals):

- **`is_driving`** (MOTION class) — ON when ignition ON3 active and gear is DRIVE or REVERSE
- **`ac_input_slow_charge`** (PLUG class, diagnostic) — ON when AC slow-charge gun inserted (signal 47)
- **`charge_completed`** (BATTERY_CHARGING class, diagnostic) — ON when chargeCompleted named field is set

Also:
- `climate_fan_volume` now falls back to signal 1941 on C10/B10 when `acAirVolume` named field is absent

## Merge order

**2 of 5** — merge after #30 which adds the `is_driving` status field.

## Test plan

- [ ] `is_driving` entity appears after restart, goes on while driving
- [ ] `ac_input_slow_charge` appears when AC cable plugged in
- [ ] `charge_completed` appears after a completed charge session
- [ ] No new entities on vehicles that don't report these signals