### PR TITLE
feat: set_climate service for parameterised AC control

### DIFF
--- a/custom_components/leapmotor/__init__.py
+++ b/custom_components/leapmotor/__init__.py
@@ -66,6 +66,18 @@ _SERVICE_SCHEMAS = {
     "sunshade_close": SUNSHADE_POSITION_SERVICE_FIELDS,
 }
 
+SET_CLIMATE_FIELDS = vol.Schema(
+    {
+        vol.Required("mode"): vol.In(["cold", "hot", "wind"]),
+        vol.Optional("temperature", default=22): vol.All(vol.Coerce(int), vol.Range(min=16, max=32)),
+        vol.Optional("fan_speed", default=4): vol.All(vol.Coerce(int), vol.Range(min=1, max=7)),
+        vol.Optional("recirculate", default=False): bool,
+        vol.Optional("windshield_defrost", default=False): bool,
+        vol.Optional("vin"): str,
+        vol.Optional("entity_id"): str,
+    }
+)
+
 SET_CHARGE_LIMIT_FIELDS = vol.Schema(
     {
         vol.Required("charge_limit_percent"): vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
@@ -275,6 +287,54 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         )
         await coordinator.async_request_refresh()
 
+    async def handle_set_climate(call: ServiceCall) -> None:
+        domain_data = hass.data.get(DOMAIN) or {}
+        if not domain_data:
+            raise HomeAssistantError("No Leapmotor config entry is loaded.")
+
+        coordinator = None
+        target_vin = call.data.get("vin")
+        entity_id = call.data.get("entity_id")
+        if entity_id:
+            state = hass.states.get(entity_id)
+            if state:
+                target_vin = state.attributes.get("vin") or target_vin
+        for candidate in domain_data.values():
+            if target_vin and target_vin not in (candidate.data.get("vehicles") or {}):
+                continue
+            try:
+                resolved_vin = resolve_target_vin(candidate, target_vin)
+            except Exception:
+                continue
+            coordinator = candidate
+            target_vin = resolved_vin
+            break
+
+        if coordinator is None or not target_vin:
+            raise HomeAssistantError(
+                "No matching Leapmotor vehicle found. Specify a VIN if multiple vehicles are configured."
+            )
+
+        try:
+            result = await hass.async_add_executor_job(
+                partial(
+                    coordinator.client.set_climate,
+                    target_vin,
+                    mode=call.data["mode"],
+                    temperature=call.data.get("temperature", 22),
+                    fan_speed=call.data.get("fan_speed", 4),
+                    recirculate=call.data.get("recirculate", False),
+                    windshield_defrost=call.data.get("windshield_defrost", False),
+                )
+            )
+        except Exception as exc:
+            message = format_remote_error(exc)
+            coordinator.record_remote_action(target_vin, "set_climate", success=False, error=message)
+            raise HomeAssistantError(message) from exc
+
+        coordinator.record_remote_action(target_vin, "set_climate", success=True, result=result)
+        await coordinator.async_request_refresh()
+
     async def handle_send_destination(call: ServiceCall) -> None:
         domain_data = hass.data.get(DOMAIN) or {}
         if not domain_data:
@@ -386,6 +446,13 @@ async def _async_register_services(hass: HomeAssistant) -> None:
         _LOGGER.debug("Registered Leapmotor service %s.%s", DOMAIN, service_name)
     hass.services.async_register(
         DOMAIN,
+        "set_climate",
+        handle_set_climate,
+        schema=SET_CLIMATE_FIELDS,
+    )
+    _LOGGER.debug("Registered Leapmotor service %s.%s", DOMAIN, "set_climate")
+    hass.services.async_register(
+        DOMAIN,
         "set_charge_limit",
         handle_set_charge_limit,
         schema=SET_CHARGE_LIMIT_FIELDS,
@@ -412,6 +479,8 @@ def _async_unregister_services(hass: HomeAssistant) -> None:
     for service_name in ("lock", "unlock", *(spec.service_name for spec in BUTTON_SPECS)):
         if hass.services.has_service(DOMAIN, service_name):
             hass.services.async_remove(DOMAIN, service_name)
+    if hass.services.has_service(DOMAIN, "set_climate"):
+        hass.services.async_remove(DOMAIN, "set_climate")
     if hass.services.has_service(DOMAIN, "set_charge_limit"):
         hass.services.async_remove(DOMAIN, "set_charge_limit")
     if hass.services.has_service(DOMAIN, "send_destination"):

--- a/custom_components/leapmotor/api.py
+++ b/custom_components/leapmotor/api.py
@@ -261,6 +261,44 @@ class LeapmotorApiClient:
         """Trigger the verified windshield-defrost profile."""
         return self._remote_control(vin=vin, action=REMOTE_CTL_WINDSHIELD_DEFROST)
 
+    def set_climate(
+        self,
+        vin: str,
+        *,
+        mode: str,
+        temperature: int = 22,
+        fan_speed: int = 4,
+        recirculate: bool = False,
+        windshield_defrost: bool = False,
+    ) -> dict[str, Any]:
+        """Send a fully parameterised climate command (cmd_id 170)."""
+        if not self.token:
+            self.login()
+        if not self.operation_password:
+            raise LeapmotorAuthError(
+                "No vehicle PIN configured. Climate control requires it."
+            )
+        vehicle = self._find_vehicle_by_vin(vin)
+        cmd_content = json.dumps(
+            {
+                "circle": "in" if recirculate else "out",
+                "mode": mode,
+                "operate": "manual",
+                "position": "all",
+                "temperature": str(temperature),
+                "windlevel": str(fan_speed),
+                "wshld": "1" if windshield_defrost else "0",
+            },
+            separators=(",", ":"),
+        )
+        return self._remote_control_raw(
+            vin=vehicle.vin,
+            cmd_id="170",
+            cmd_content=cmd_content,
+            action_label="set_climate",
+            vehicle=vehicle,
+        )
+
     def set_charge_limit(self, vin: str, charge_limit_percent: int) -> dict[str, Any]:
         """Set the charge limit while preserving the current charging plan values."""
         return self._set_charging_plan(vin, charge_limit_percent=charge_limit_percent)

--- a/custom_components/leapmotor/strings.json
+++ b/custom_components/leapmotor/strings.json
@@ -1,0 +1,34 @@
+{
+  "services": {
+    "set_climate": {
+      "name": "Set climate",
+      "description": "Send a fully parameterised climate command to the vehicle (cmd_id 170). Requires PIN.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Climate mode: cold (cooling), hot (heating), or wind (ventilation only)."
+        },
+        "temperature": {
+          "name": "Temperature",
+          "description": "Target temperature in degrees Celsius (16–32, default 22)."
+        },
+        "fan_speed": {
+          "name": "Fan speed",
+          "description": "Fan speed level (1–7, default 4)."
+        },
+        "recirculate": {
+          "name": "Recirculate",
+          "description": "True = recirculate cabin air, False = use outside air (default)."
+        },
+        "windshield_defrost": {
+          "name": "Windshield defrost",
+          "description": "Enable front windshield defrost (default false)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Vehicle identification number. Required when multiple vehicles are configured."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/leapmotor/translations/de.json
+++ b/custom_components/leapmotor/translations/de.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Klimaanlage steuern",
+      "description": "Klimabefehl mit individuellen Parametern senden. PIN erforderlich.",
+      "fields": {
+        "mode": {
+          "name": "Modus",
+          "description": "Klimamodus: cold (Kühlen), hot (Heizen) oder wind (nur Lüften)."
+        },
+        "temperature": {
+          "name": "Temperatur",
+          "description": "Zieltemperatur in °C (16–32, Standard 22)."
+        },
+        "fan_speed": {
+          "name": "Lüfterstufe",
+          "description": "Lüftergeschwindigkeit (1–7, Standard 4)."
+        },
+        "recirculate": {
+          "name": "Umluft",
+          "description": "True = Umluft, False = Frischluft (Standard)."
+        },
+        "windshield_defrost": {
+          "name": "Frontscheibenheizung",
+          "description": "Frontscheibenheizung aktivieren (Standard: aus)."
+        },
+        "vin": {
+          "name": "FIN",
+          "description": "Fahrzeugidentifikationsnummer. Erforderlich bei mehreren Fahrzeugen."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/en.json
+++ b/custom_components/leapmotor/translations/en.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Set climate",
+      "description": "Send a fully parameterised climate command to the vehicle. Requires PIN.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Climate mode: cold (cooling), hot (heating), or wind (ventilation only)."
+        },
+        "temperature": {
+          "name": "Temperature",
+          "description": "Target temperature in °C (16–32, default 22)."
+        },
+        "fan_speed": {
+          "name": "Fan speed",
+          "description": "Fan speed level (1–7, default 4)."
+        },
+        "recirculate": {
+          "name": "Recirculate",
+          "description": "True = recirculate cabin air, False = outside air (default)."
+        },
+        "windshield_defrost": {
+          "name": "Windshield defrost",
+          "description": "Enable front windshield defrost (default false)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Vehicle identification number. Required when multiple vehicles are configured."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/es.json
+++ b/custom_components/leapmotor/translations/es.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Configurar climatización",
+      "description": "Envía un comando de climatización con parámetros personalizados. Requiere PIN.",
+      "fields": {
+        "mode": {
+          "name": "Modo",
+          "description": "Modo: cold (refrigeración), hot (calefacción) o wind (solo ventilación)."
+        },
+        "temperature": {
+          "name": "Temperatura",
+          "description": "Temperatura objetivo en °C (16–32, predeterminado 22)."
+        },
+        "fan_speed": {
+          "name": "Velocidad del ventilador",
+          "description": "Nivel de velocidad del ventilador (1–7, predeterminado 4)."
+        },
+        "recirculate": {
+          "name": "Recircular",
+          "description": "True = recircular aire interior, False = aire exterior (predeterminado)."
+        },
+        "windshield_defrost": {
+          "name": "Descongelación del parabrisas",
+          "description": "Activar descongelación del parabrisas delantero (predeterminado: no)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Número de identificación del vehículo. Obligatorio con varios vehículos."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/fr.json
+++ b/custom_components/leapmotor/translations/fr.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Régler la climatisation",
+      "description": "Envoie une commande de climatisation avec des paramètres personnalisés. PIN requis.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Mode : cold (refroidissement), hot (chauffage) ou wind (ventilation seule)."
+        },
+        "temperature": {
+          "name": "Température",
+          "description": "Température cible en °C (16–32, défaut 22)."
+        },
+        "fan_speed": {
+          "name": "Vitesse du ventilateur",
+          "description": "Niveau de vitesse du ventilateur (1–7, défaut 4)."
+        },
+        "recirculate": {
+          "name": "Recirculation",
+          "description": "True = recycler l'air intérieur, False = air extérieur (défaut)."
+        },
+        "windshield_defrost": {
+          "name": "Dégivrage pare-brise",
+          "description": "Activer le dégivrage du pare-brise avant (défaut : non)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Numéro d'identification du véhicule. Obligatoire si plusieurs véhicules."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/it.json
+++ b/custom_components/leapmotor/translations/it.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Imposta climatizzazione",
+      "description": "Invia un comando clima con parametri personalizzati. Richiede PIN.",
+      "fields": {
+        "mode": {
+          "name": "Modalità",
+          "description": "Modalità: cold (raffreddamento), hot (riscaldamento) o wind (solo ventilazione)."
+        },
+        "temperature": {
+          "name": "Temperatura",
+          "description": "Temperatura target in °C (16–32, predefinito 22)."
+        },
+        "fan_speed": {
+          "name": "Velocità ventilatore",
+          "description": "Livello velocità ventilatore (1–7, predefinito 4)."
+        },
+        "recirculate": {
+          "name": "Ricircolo",
+          "description": "True = ricircolo aria interna, False = aria esterna (predefinito)."
+        },
+        "windshield_defrost": {
+          "name": "Sbrinamento parabrezza",
+          "description": "Attiva sbrinamento parabrezza anteriore (predefinito: no)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Numero identificazione veicolo. Obbligatorio con più veicoli."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/nl.json
+++ b/custom_components/leapmotor/translations/nl.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Klimaat instellen",
+      "description": "Stuur een klimaatopdracht met aangepaste parameters. PIN vereist.",
+      "fields": {
+        "mode": {
+          "name": "Modus",
+          "description": "Klimaatmodus: cold (koelen), hot (verwarmen) of wind (alleen ventileren)."
+        },
+        "temperature": {
+          "name": "Temperatuur",
+          "description": "Doeltemperatuur in °C (16–32, standaard 22)."
+        },
+        "fan_speed": {
+          "name": "Ventilatorsnelheid",
+          "description": "Ventilatorsnelheidsniveau (1–7, standaard 4)."
+        },
+        "recirculate": {
+          "name": "Recirculeren",
+          "description": "True = binnenlucht recirculeren, False = buitenlucht (standaard)."
+        },
+        "windshield_defrost": {
+          "name": "Voorruit ontdooien",
+          "description": "Voorruit ontdooien inschakelen (standaard: nee)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Voertuigidentificatienummer. Verplicht bij meerdere voertuigen."
+        }
+      }
+    }
   }
 }

--- a/custom_components/leapmotor/translations/pl.json
+++ b/custom_components/leapmotor/translations/pl.json
@@ -515,5 +515,37 @@
         }
       }
     }
+  },
+  "services": {
+    "set_climate": {
+      "name": "Ustaw klimatyzację",
+      "description": "Wyślij sparametryzowane polecenie klimatyzacji. Wymagany PIN.",
+      "fields": {
+        "mode": {
+          "name": "Tryb",
+          "description": "Tryb: cold (chłodzenie), hot (ogrzewanie) lub wind (tylko wentylacja)."
+        },
+        "temperature": {
+          "name": "Temperatura",
+          "description": "Docelowa temperatura w °C (16–32, domyślnie 22)."
+        },
+        "fan_speed": {
+          "name": "Prędkość wentylatora",
+          "description": "Poziom prędkości wentylatora (1–7, domyślnie 4)."
+        },
+        "recirculate": {
+          "name": "Recyrkulacja",
+          "description": "True = recyrkulacja powietrza kabiny, False = powietrze zewnętrzne (domyślnie)."
+        },
+        "windshield_defrost": {
+          "name": "Odmrażanie przedniej szyby",
+          "description": "Włącz odmrażanie przedniej szyby (domyślnie: nie)."
+        },
+        "vin": {
+          "name": "VIN",
+          "description": "Numer identyfikacyjny pojazdu. Wymagany przy wielu pojazdach."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #28

## Summary

Adds a `leapmotor.set_climate` HA service that exposes full control over the climate command (cmd_id 170) — mode, temperature, fan speed, air circulation, and windshield defrost — instead of the fixed presets that `quick_cool` / `quick_heat` / `ac_switch` provide.

**Service fields:**

| Field | Type | Default | Description |
|---|---|---|---|
| `mode` | `cold` \| `hot` \| `wind` | required | Cooling, heating, or ventilation only |
| `temperature` | int 16–32 | 22 | Target °C |
| `fan_speed` | int 1–7 | 4 | Fan speed level |
| `recirculate` | bool | false | Recirculate cabin air vs. fresh outside air |
| `windshield_defrost` | bool | false | Front windshield defrost |
| `vin` | str | — | Required when multiple vehicles configured |

**Example (heat to 26°C, fan speed 5, recirculate):**
```yaml
service: leapmotor.set_climate
data:
  mode: hot
  temperature: 26
  fan_speed: 5
  recirculate: true
```

## Implementation

- `api.py`: `set_climate()` builds `cmd_content` from parameters and calls `_remote_control_raw` directly with `cmd_id="170"`. Includes inline token + PIN guard.
- `__init__.py`: `SET_CLIMATE_FIELDS` voluptuous schema, `handle_set_climate` handler following the same VIN-resolution pattern as `handle_set_charge_limit`. Registered and unregistered with the other services.
- `strings.json`: Created (new file) with full service + field descriptions.
- Translations: `set_climate` service added to all 7 language files (de, en, es, fr, it, nl, pl).

## Test plan

- [ ] `leapmotor.set_climate` appears in Developer Tools → Services with field descriptions
- [ ] `mode: cold, temperature: 20, fan_speed: 3` cools the car
- [ ] `mode: hot, temperature: 28` heats with default fan speed
- [ ] `mode: wind` runs ventilation without heating/cooling
- [ ] `recirculate: true` triggers cabin air recirculation
- [ ] `windshield_defrost: true` activates front defrost
- [ ] Calling without PIN raises a clear error
- [ ] Existing `quick_cool`, `quick_heat`, `ac_switch` buttons unaffected